### PR TITLE
Fix linting errors blocking CI pipeline

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -9,20 +9,16 @@ import { MetadataWriter } from './services/metadataWriter';
 import type { AppConfig } from '../src/types';
 
 let mainWindow: BrowserWindow | null = null;
-let fileManager: FileManager;
+const fileManager: FileManager = new FileManager();
 let metadataStore: MetadataStore | null = null;
 let currentFolderPath: string | null = null;
-let configManager: ConfigManager;
-let metadataWriter: MetadataWriter;
+const configManager: ConfigManager = (() => {
+  const userDataPath = app.getPath('userData');
+  const configPath = path.join(userDataPath, 'config.yaml');
+  return new ConfigManager(configPath);
+})();
+const metadataWriter: MetadataWriter = new MetadataWriter();
 let aiService: AIService | null = null;
-
-// Initialize services
-const userDataPath = app.getPath('userData');
-const configPath = path.join(userDataPath, 'config.yaml');
-
-fileManager = new FileManager();
-configManager = new ConfigManager(configPath);
-metadataWriter = new MetadataWriter();
 
 // Helper function to get or create metadata store for a specific folder
 function getMetadataStoreForFolder(folderPath: string): MetadataStore {

--- a/electron/services/configManager.test.ts
+++ b/electron/services/configManager.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs/promises';
-import * as path from 'path';
 import { ConfigManager } from './configManager';
-import type { AppConfig, Lexicon } from '../../src/types';
+import type { AppConfig } from '../../src/types';
 
 // Mock fs module
 vi.mock('fs/promises');

--- a/electron/services/metadataWriter.ts
+++ b/electron/services/metadataWriter.ts
@@ -43,7 +43,7 @@ export class MetadataWriter {
     const exiftoolCmd = `exiftool ${commands.join(' ')} "${filePath}"`;
 
     try {
-      const { stdout, stderr } = await execAsync(exiftoolCmd);
+      const { stderr } = await execAsync(exiftoolCmd);
       if (stderr && !stderr.includes('1 image files updated')) {
         console.error('exiftool stderr:', stderr);
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,24 +23,17 @@ function App() {
     }
   }, [statusMessage]);
 
-  // Check if running in Electron (user-friendly UI check)
-  if (!window.electronAPI) {
-    return (
-      <div className="app" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', flexDirection: 'column', gap: '16px' }}>
-        <h2>⚠️ Electron API not available</h2>
-        <p>This app must be run in Electron, not in a browser.</p>
-        <p>Run: <code>npm run dev</code></p>
-      </div>
-    );
-  }
-
   // Check if AI is configured on mount
   useEffect(() => {
-    window.electronAPI.isAIConfigured().then(setIsAIConfigured);
+    if (window.electronAPI) {
+      window.electronAPI.isAIConfigured().then(setIsAIConfigured);
+    }
   }, []);
 
   // Update form and load media when current file changes
   useEffect(() => {
+    if (!window.electronAPI) return;
+
     if (currentFile) {
       setMainName(currentFile.mainName);
       setMetadata(currentFile.metadata.join(', '));
@@ -56,6 +49,17 @@ function App() {
       setMediaDataUrl('');
     }
   }, [currentFile]);
+
+  // Check if running in Electron (user-friendly UI check)
+  if (!window.electronAPI) {
+    return (
+      <div className="app" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', flexDirection: 'column', gap: '16px' }}>
+        <h2>⚠️ Electron API not available</h2>
+        <p>This app must be run in Electron, not in a browser.</p>
+        <p>Run: <code>npm run dev</code></p>
+      </div>
+    );
+  }
 
   const handleSelectFolder = async () => {
     const path = await window.electronAPI.selectFolder();


### PR DESCRIPTION
Fixed lint errors across 4 files:
- electron/main.ts: Changed let → const for fileManager, configManager, metadataWriter (prefer-const)
- configManager.test.ts: Removed unused imports (path, Lexicon)
- metadataWriter.ts: Removed unused stdout variable
- App.tsx: Fixed React Hooks order violation by moving useEffect calls before early return

All errors resolved. Only 6 warnings remain (no-explicit-any).