### PR TITLE
Replace TypeScript 'any' types with proper types

### DIFF
--- a/electron/services/configManager.test.ts
+++ b/electron/services/configManager.test.ts
@@ -9,7 +9,12 @@ vi.mock('fs/promises');
 describe('ConfigManager', () => {
   let configManager: ConfigManager;
   const testConfigPath = '/test/config.yaml';
-  const mockFs = fs as any;
+  // Partial mock of fs/promises for testing (explicit unknown cast)
+  const mockFs = fs as unknown as {
+    readFile: ReturnType<typeof vi.fn>;
+    mkdir: ReturnType<typeof vi.fn>;
+    writeFile: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/electron/services/configManager.ts
+++ b/electron/services/configManager.ts
@@ -21,8 +21,9 @@ export class ConfigManager {
       const config = yaml.load(content) as AppConfig;
       this.cachedConfig = config;
       return config;
-    } catch (error: any) {
-      if (error.code === 'ENOENT') {
+    } catch (error) {
+      // Type guard: Check if error has code property (NodeJS.ErrnoException)
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
         // File doesn't exist, return default config
         this.cachedConfig = this.getDefaultConfig();
         return this.cachedConfig;

--- a/electron/services/fileManager.test.ts
+++ b/electron/services/fileManager.test.ts
@@ -7,7 +7,12 @@ vi.mock('fs/promises');
 
 describe('FileManager', () => {
   let fileManager: FileManager;
-  const mockFs = fs as any;
+  // Partial mock of fs/promises for testing (explicit unknown cast)
+  const mockFs = fs as unknown as {
+    readdir: ReturnType<typeof vi.fn>;
+    stat: ReturnType<typeof vi.fn>;
+    rename: ReturnType<typeof vi.fn>;
+  };
   const testFolderPath = '/test/folder';
 
   beforeEach(() => {

--- a/electron/services/metadataStore.test.ts
+++ b/electron/services/metadataStore.test.ts
@@ -8,7 +8,12 @@ vi.mock('fs/promises');
 describe('MetadataStore', () => {
   let metadataStore: MetadataStore;
   const testStorePath = '/test/metadata.json';
-  const mockFs = fs as any;
+  // Partial mock of fs/promises for testing (explicit unknown cast)
+  const mockFs = fs as unknown as {
+    readFile: ReturnType<typeof vi.fn>;
+    mkdir: ReturnType<typeof vi.fn>;
+    writeFile: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/electron/services/metadataStore.ts
+++ b/electron/services/metadataStore.ts
@@ -29,8 +29,9 @@ export class MetadataStore {
 
       this.cache = data;
       return data;
-    } catch (error: any) {
-      if (error.code === 'ENOENT') {
+    } catch (error) {
+      // Type guard: Check if error has code property (NodeJS.ErrnoException)
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
         // File doesn't exist, return empty store
         this.cache = {};
         return {};

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -18,7 +18,12 @@ const mockElectronAPI = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  (global as any).window.electronAPI = mockElectronAPI;
+  // Extend window with electronAPI for testing
+  Object.defineProperty(window, 'electronAPI', {
+    value: mockElectronAPI,
+    writable: true,
+    configurable: true,
+  });
   mockElectronAPI.isAIConfigured.mockResolvedValue(false);
 });
 


### PR DESCRIPTION
Eliminated all @typescript-eslint/no-explicit-any warnings across the codebase by using proper type guards and explicit type assertions.

## Changes

**Source Files (Error Handling):**
- configManager.ts: Use type guard for NodeJS.ErrnoException
- metadataStore.ts: Use type guard for NodeJS.ErrnoException

Instead of `catch (error: any)`, use proper type guard:
```typescript
catch (error) {
  if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
    // Handle file not found
  }
  throw error;
}
```

**Test Files (Mock Types):**
- fileManager.test.ts: Explicit partial mock type
- metadataStore.test.ts: Explicit partial mock type
- configManager.test.ts: Explicit partial mock type
- App.test.tsx: Use Object.defineProperty for window extension

Replaced `as any` with explicit partial mock interfaces:
```typescript
const mockFs = fs as unknown as {
  readFile: ReturnType<typeof vi.fn>;
  writeFile: ReturnType<typeof vi.fn>;
  mkdir: ReturnType<typeof vi.fn>;
};
```

## Rationale

**Source Code:**
- Type guards provide runtime safety
- Clear documentation of expected error properties
- Maintains type safety while handling unknown errors

**Tests:**
- `as unknown as` double cast is explicit (better than `as any`)
- Documents which mock methods are actually used
- Satisfies linter without requiring full type implementation
- Allows partial mocks (pragmatic for testing)

## Verification

✅ TypeScript: `tsc --noEmit` passes (0 errors)
✅ ESLint: `npm run lint` passes (0 warnings)
✅ All tests: Continue to pass with proper types

## Future-Proofing

Type patterns documented in code comments for consistency. Developers can follow these patterns for new files.

Fixes: All @typescript-eslint/no-explicit-any warnings