### PR TITLE
feat: add action field support for video naming (4-part format)

### DIFF
--- a/prompts/structured-analysis.md
+++ b/prompts/structured-analysis.md
@@ -2,22 +2,29 @@
 
 This prompt template is used for analyzing images/videos and generating structured metadata.
 
-**Format:** `{location}-{subject}-{shotType}`
+**Format:**
+- Photos: `{location}-{subject}-{shotType}` (3 parts)
+- Videos: `{location}-{subject}-{action}-{shotType}` (4 parts)
 
 **Variables available:**
 - `{{locations}}` - Comma-separated list of common locations
 - `{{subjects}}` - Comma-separated list of common subjects
+- `{{actions}}` - Comma-separated list of common actions (videos only)
 - `{{staticShots}}` - Comma-separated list of static shot types
 - `{{movingShots}}` - Comma-separated list of moving shot types
 - `{{wordPreferences}}` - Synonym mappings (e.g., "faucet" -> "tap")
 - `{{aiInstructions}}` - Custom instructions from lexicon config
+- `{{goodExamples}}` - Good example filenames
+- `{{badExamples}}` - Bad example filenames with reasons
 
 ---
 
 ## Prompt (Edit Below)
 
-Analyze this image and generate structured metadata following this pattern:
-**{location}-{subject}-{shotType}**
+Analyze this image/video and generate structured metadata following these patterns:
+
+**PHOTOS:** `{location}-{subject}-{shotType}` (3 parts)
+**VIDEOS:** `{location}-{subject}-{action}-{shotType}` (4 parts)
 
 ### LOCATION
 Identify where the shot takes place.
@@ -32,6 +39,15 @@ Identify the main object or feature being captured.
 **Common subjects:** {{subjects}}
 
 You can use custom subjects not in this list if more appropriate.
+
+### ACTION (VIDEOS ONLY)
+For videos, identify the action being performed or demonstrated.
+
+**Common actions:** {{actions}}
+
+Examples: cleaning, installing, replacing, inspecting, removing, adjusting
+
+**IMPORTANT:** Only include action for videos. Photos use 3-part naming without action.
 
 ### SHOT TYPE
 Determine the framing category.
@@ -66,6 +82,7 @@ Use these terms consistently:
 
 **CRITICAL:** Return ONLY valid JSON in this exact format (no markdown, no explanation):
 
+**For photos (3-part naming):**
 ```json
 {
   "location": "location-name",
@@ -76,7 +93,21 @@ Use these terms consistently:
 }
 ```
 
-### Example Response
+**For videos (4-part naming with action):**
+```json
+{
+  "location": "location-name",
+  "subject": "subject-name",
+  "action": "action-verb",
+  "shotType": "SHOT_TYPE",
+  "mainName": "location-subject-action-SHOT_TYPE",
+  "metadata": ["tag1", "tag2"]
+}
+```
+
+### Example Responses
+
+**Photo example:**
 ```json
 {
   "location": "kitchen",
@@ -84,6 +115,18 @@ Use these terms consistently:
   "shotType": "CU",
   "mainName": "kitchen-oven-CU",
   "metadata": ["appliance", "control-panel", "interior"]
+}
+```
+
+**Video example:**
+```json
+{
+  "location": "kitchen",
+  "subject": "dishwasher",
+  "action": "cleaning",
+  "shotType": "MID",
+  "mainName": "kitchen-dishwasher-cleaning-MID",
+  "metadata": ["appliance", "maintenance", "tutorial"]
 }
 ```
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,8 @@ export interface FileMetadata {
   location?: string;
   /** Main subject/object in shot (e.g., "oven", "sink") */
   subject?: string;
+  /** Action being performed (videos only, e.g., "cleaning", "installing") */
+  action?: string;
   /** Shot type from controlled vocabulary */
   shotType?: ShotType;
 }
@@ -145,7 +147,7 @@ export interface AIConnectionTestResult {
 }
 
 export interface AIAnalysisResult {
-  /** Structured main name: {location}-{subject}-{shotType} */
+  /** Structured main name: {location}-{subject}-{shotType} or {location}-{subject}-{action}-{shotType} */
   mainName: string;
   /** Array of metadata tags */
   metadata: string[];
@@ -157,6 +159,8 @@ export interface AIAnalysisResult {
   location?: string;
   /** Subject component */
   subject?: string;
+  /** Action component (videos only) */
+  action?: string;
   /** Shot type component */
   shotType?: ShotType;
 }


### PR DESCRIPTION
Implements action extraction and UI support for videos, enabling 4-part naming pattern: {location}-{subject}-{action}-{shotType}

**Changes:**

**Types (src/types/index.ts):**
- Added optional `action?: string` to FileMetadata
- Added optional `action?: string` to AIAnalysisResult
- Updated mainName comment to reflect both formats

**AI Prompt (prompts/structured-analysis.md):**
- Updated format documentation (3-part photos, 4-part videos)
- Added ACTION section with guidance and common actions
- Added {{actions}} variable documentation
- Updated response format examples for photos vs videos
- Added video example with action field

**UI (src/App.tsx):**
- Added action state and input field
- Action field disabled/grayed for photos (opacity 50%)
- Action field enabled for videos
- Updated filename generation:
  - Photos: {location}-{subject}-{shotType} (3-part)
  - Videos: {location}-{subject}-{action}-{shotType} (4-part)
- Updated file parsing to handle both formats
- AI result populates action field automatically

**Quality Gates:**
✅ Typecheck: PASSED (0 errors)
✅ Tests: 222/222 passing (100%)
✅ Lint: 0 errors (31 pre-existing warnings)

**Behavior:**
- Photos: Action field disabled, 3-part naming maintained
- Videos: Action field enabled, 4-part naming when action provided
- Backward compatible: Handles legacy 3-part video files
- AI integration: Action extracted automatically for videos

🤖 Generated with [Claude Code](https://claude.com/claude-code)