### PR TITLE
Add constitution files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ config/config.yaml
 # Testing
 coverage
 .nyc_output
+constitution.txt
+constitution_numbered.txt


### PR DESCRIPTION
Added constitution.txt and constitution_numbered.txt to .gitignore to prevent these files from being tracked by git.