### PR TITLE
Optimize file metadata save to avoid unnecessary reloads

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -414,6 +414,7 @@ ipcMain.handle('file:load-files', async () => {
       // Preserve structured naming components
       file.location = existingMetadata.location;
       file.subject = existingMetadata.subject;
+      file.action = existingMetadata.action;
       file.shotType = existingMetadata.shotType;
     }
   }


### PR DESCRIPTION
Added logic to update file metadata in place without reloading all files when the file is not renamed, preventing unnecessary video re-transcoding. Also ensured the 'action' field is preserved when loading files in the Electron main process.