### PR TITLE
Ensure unique file names across systems

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -96,6 +96,66 @@ let aiService: AIService | null = null;
 const batchQueuePath = path.join(app.getPath('userData'), '.ingest-batch-queue.json');
 const batchQueueManager: BatchQueueManager = new BatchQueueManager(batchQueuePath);
 
+/**
+ * Format a Date object as yyyymmddhhmm for use in filenames
+ * Example: 2025-11-03 10:05:30 -> 202511031005
+ */
+function formatTimestampForTitle(date: Date): string {
+  const year = date.getFullYear().toString();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  const hour = date.getHours().toString().padStart(2, '0');
+  const minute = date.getMinutes().toString().padStart(2, '0');
+
+  return `${year}${month}${day}${hour}${minute}`;
+}
+
+/**
+ * Get or extract creation timestamp from file metadata.
+ * Returns cached timestamp if available, otherwise extracts from file using exiftool.
+ * Caches the result in the FileMetadata object for future use.
+ */
+async function getOrExtractCreationTimestamp(
+  fileMetadata: import('../src/types').FileMetadata
+): Promise<Date | undefined> {
+  // Return cached timestamp if available
+  if (fileMetadata.creationTimestamp) {
+    return fileMetadata.creationTimestamp;
+  }
+
+  // Extract from file using exiftool
+  const timestamp = await metadataWriter.readCreationTimestamp(fileMetadata.filePath);
+
+  // Cache in metadata object
+  if (timestamp) {
+    fileMetadata.creationTimestamp = timestamp;
+  }
+
+  return timestamp;
+}
+
+/**
+ * Generate title with timestamp suffix.
+ * Takes a base title and appends creation timestamp in yyyymmddhhmm format.
+ * Example: "kitchen-oven-CU" + timestamp -> "kitchen-oven-CU-202511031005"
+ */
+async function generateTitleWithTimestamp(
+  baseTitle: string,
+  fileMetadata: import('../src/types').FileMetadata
+): Promise<string> {
+  const timestamp = await getOrExtractCreationTimestamp(fileMetadata);
+
+  if (timestamp) {
+    const formattedTimestamp = formatTimestampForTitle(timestamp);
+    return `${baseTitle}-${formattedTimestamp}`;
+  }
+
+  // If no timestamp available, return base title as-is
+  // This maintains backward compatibility for files without timestamp metadata
+  console.warn(`[generateTitleWithTimestamp] No creation timestamp found for ${fileMetadata.filePath}, using base title only`);
+  return baseTitle;
+}
+
 // Register transcode cache directory with security validator
 // This allows the media server to serve transcoded files
 // IMPORTANT: Resolve symlinks (macOS /var -> /private/var) to match validation behavior
@@ -709,9 +769,12 @@ ipcMain.handle('file:update-structured-metadata', async (_event, fileId: string,
     fileMetadata.shotType = validatedStructured.shotType as ShotType;
 
     // Build generated title from structured components
-    const generatedTitle = fileMetadata.fileType === 'video' && structured.action
+    const baseTitle = fileMetadata.fileType === 'video' && structured.action
       ? `${structured.location}-${structured.subject}-${structured.action}-${structured.shotType}`
       : `${structured.location}-${structured.subject}-${structured.shotType}`;
+
+    // Append timestamp to title for uniqueness
+    const generatedTitle = await generateTitleWithTimestamp(baseTitle, fileMetadata);
 
     // Update mainName to match generated title
     fileMetadata.mainName = generatedTitle;
@@ -832,7 +895,8 @@ ipcMain.handle('ai:batch-process', async (_event, fileIds: string[]) => {
 
       // Auto-update if confidence is high
       if (result.confidence > 0.7) {
-        fileMetadata.mainName = result.mainName;
+        // Append timestamp to AI-generated name for uniqueness
+        fileMetadata.mainName = await generateTitleWithTimestamp(result.mainName, fileMetadata);
         fileMetadata.metadata = result.metadata;
         fileMetadata.processedByAI = true;
         await store.updateFileMetadata(fileId, fileMetadata);
@@ -922,7 +986,8 @@ ipcMain.handle('batch:start', async (_event, fileIds: string[]) => {
 
         // Auto-update if confidence is high
         if (result.confidence > 0.7) {
-          fileMetadata.mainName = result.mainName;
+          // Append timestamp to AI-generated name for uniqueness
+          fileMetadata.mainName = await generateTitleWithTimestamp(result.mainName, fileMetadata);
           fileMetadata.metadata = result.metadata;
           fileMetadata.location = result.location;
           fileMetadata.subject = result.subject;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,8 @@ export interface FileMetadata {
   processedByAI: boolean;
   /** Last modified timestamp */
   lastModified: Date;
+  /** Original creation timestamp from camera/device (used for unique naming) */
+  creationTimestamp?: Date;
   /** File type: image or video */
   fileType: 'image' | 'video';
 


### PR DESCRIPTION
Added timestamp suffix in yyyymmddhhmm format to all generated titles to ensure uniqueness across file renames and prevent naming conflicts.

Changes:
- Added creationTimestamp field to FileMetadata interface
- Created readCreationTimestamp() method in MetadataWriter to extract timestamp from media files using exiftool (DateTimeOriginal, CreateDate, MediaCreateDate, CreationDate, or TrackCreateDate)
- Added helper functions in main.ts:
  - formatTimestampForTitle(): formats Date as yyyymmddhhmm
  - getOrExtractCreationTimestamp(): lazy-loads and caches timestamps
  - generateTitleWithTimestamp(): appends timestamp to base title
- Updated title generation in updateStructuredMetadata handler
- Updated AI batch processing to append timestamps to AI-generated names

Example: kitchen-oven-CU -> kitchen-oven-CU-202511031005

This solves naming conflicts when files are recategorized, as timestamps remain consistent regardless of description changes.