### PR TITLE
fix: preserve file timestamps during CFEx transfer

### DIFF
--- a/.coord/issues/ISSUE-rsync-enhancement.md
+++ b/.coord/issues/ISSUE-rsync-enhancement.md
@@ -1,0 +1,73 @@
+# GitHub Issue: Enhancement - Evaluate rsync for CFEx bulk transfer
+
+**Create at:** https://github.com/elevanaltd/ingest-assistant/issues/new
+
+---
+
+## Title
+
+Enhancement: Evaluate rsync for CFEx bulk transfer
+
+## Labels
+
+`enhancement`
+
+## Body
+
+### Summary
+
+Evaluate replacing the current streaming file transfer implementation with `rsync` for CFEx card transfers.
+
+### Context
+
+The current `transferFile()` in `cfexTransfer.ts` uses Node.js streaming (`createReadStream` → `pipeline` → `createWriteStream`). While this provides fine-grained per-file progress, rsync offers several advantages for bulk media transfers.
+
+### rsync Advantages
+
+| Aspect | Current (streaming) | rsync |
+|--------|---------------------|-------|
+| **Timestamps** | Requires manual `fs.utimes()` | ✅ Preserved with `-a` |
+| **Permissions** | ❌ Not preserved | ✅ Preserved |
+| **Network resilience** | Manual retry logic | Built-in `--partial` |
+| **Progress** | Per-file bytes | Overall % via `--info=progress2` |
+| **Battle-tested** | Custom implementation | Industry standard |
+
+### Proposed Implementation
+
+```bash
+# Photos to LucidLink
+rsync -a --info=progress2 \
+  --include='*.jpg' --include='*.jpeg' --exclude='*' \
+  "/media/card/DCIM/100_FUJI/" \
+  "/destination/photos/"
+
+# Videos to Ubuntu
+rsync -a --info=progress2 \
+  --include='*.mov' --include='*.mp4' --exclude='*' \
+  "/media/card/DCIM/100_FUJI/" \
+  "/destination/videos/"
+```
+
+### Considerations
+
+1. **Dual-destination routing**: Would need two rsync calls (one for photos, one for videos)
+2. **Progress UI**: Would show overall % instead of per-file bytes
+3. **Post-transfer validation**: EXIF extraction would remain as separate step
+4. **External dependency**: rsync is standard on macOS/Linux but not Node.js native
+
+### Acceptance Criteria
+
+- [ ] Benchmark rsync vs current implementation (transfer speed, CPU usage)
+- [ ] Prototype progress parsing from `--info=progress2` output
+- [ ] Verify all metadata preserved (timestamps, permissions)
+- [ ] Test with LucidLink and NFS destinations
+- [ ] Evaluate error handling granularity (batch vs per-file)
+
+### Priority
+
+LOW - Current implementation works, timestamp issue addressed via `fs.utimes()`
+
+### References
+
+- Current implementation: `electron/services/cfexTransfer.ts`
+- rsync man page: https://linux.die.net/man/1/rsync

--- a/electron/services/__tests__/cfexTransfer.transferFile.test.ts
+++ b/electron/services/__tests__/cfexTransfer.transferFile.test.ts
@@ -191,6 +191,63 @@ describe('transferFile', () => {
   });
 
   /**
+   * TIMESTAMP PRESERVATION TEST: Source file timestamps preserved on destination
+   *
+   * Validates:
+   * - Destination file mtime matches source file mtime
+   * - Destination file atime matches source file atime
+   * - Timestamps not overwritten with current time
+   *
+   * Reference: Issue #119 - CFEx transfer was creating files with current
+   * timestamps instead of preserving original capture timestamps.
+   */
+  test('preserves source file timestamps on destination (mtime/atime)', async () => {
+    // ARRANGE: Create test file with specific timestamp (1 week ago)
+    const sourceFile = path.join(SOURCE_DIR, 'test-timestamp.jpg');
+    const destFile = path.join(DEST_DIR, 'test-timestamp.jpg');
+
+    // Create test file
+    const testData = Buffer.alloc(1024, 't'); // 1KB
+    await fs.writeFile(sourceFile, testData);
+
+    // Set source file timestamp to 1 week ago (clearly different from now)
+    const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    await fs.utimes(sourceFile, oneWeekAgo, oneWeekAgo);
+
+    // Verify source timestamp was set correctly
+    const sourceStats = await fs.stat(sourceFile);
+    expect(Math.abs(sourceStats.mtime.getTime() - oneWeekAgo.getTime())).toBeLessThan(1000);
+
+    const mockTask: FileTransferTask = {
+      source: sourceFile,
+      destination: destFile,
+      size: 1024,
+      mediaType: 'photo',
+      enqueued: Date.now(),
+    };
+
+    // ACT: Transfer file
+    const result = await transferFile(mockTask);
+
+    // ASSERT: Transfer succeeded
+    expect(result.success).toBe(true);
+
+    // ASSERT: Destination timestamps match source
+    const destStats = await fs.stat(destFile);
+
+    // mtime should match (within 1 second tolerance for filesystem precision)
+    expect(Math.abs(destStats.mtime.getTime() - sourceStats.mtime.getTime())).toBeLessThan(1000);
+
+    // atime should match (within 1 second tolerance)
+    expect(Math.abs(destStats.atime.getTime() - sourceStats.atime.getTime())).toBeLessThan(1000);
+
+    // Verify timestamps are NOT current time (would indicate bug)
+    const now = Date.now();
+    const mtimeDiffFromNow = Math.abs(destStats.mtime.getTime() - now);
+    expect(mtimeDiffFromNow).toBeGreaterThan(6 * 24 * 60 * 60 * 1000); // More than 6 days ago
+  });
+
+  /**
    * PROGRESS THROTTLING TEST: Progress updates throttled to prevent UI flooding
    *
    * Validates:

--- a/electron/services/cfexTransfer.ts
+++ b/electron/services/cfexTransfer.ts
@@ -249,6 +249,9 @@ export async function transferFile(
   // Ensure destination directory exists
   await fs.mkdir(path.dirname(task.destination), { recursive: true });
 
+  // Capture source timestamps BEFORE transfer (reading file updates atime)
+  const sourceStats = await fs.stat(task.source);
+
   // Stream with 64KB chunks (per D3 Blueprint L265)
   const readStream = createReadStream(task.source, {
     highWaterMark: 64 * 1024, // 64KB chunks
@@ -291,6 +294,10 @@ export async function transferFile(
   // Transfer with error handling
   try {
     await pipeline(readStream, writeStream);
+
+    // Preserve source file timestamps on destination (Issue #119)
+    // Without this, destination gets current timestamp instead of original capture time
+    await fs.utimes(task.destination, sourceStats.atime, sourceStats.mtime);
   } catch (error) {
     // Clean up partial file on error (per D3 Blueprint L291-296)
     try {


### PR DESCRIPTION
The CFEx file transfer was creating destination files with current timestamps instead of preserving the original capture timestamps (mtime/atime). This caused audit trail loss and broke chronological ordering expectations.

Changes:
- Capture source file stats BEFORE streaming transfer (to avoid atime update from reading)
- Apply fs.utimes() after successful transfer to copy timestamps
- Add comprehensive test for timestamp preservation

Also adds rsync enhancement tracking issue for future consideration.

Fixes timestamp preservation gap identified in production testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)