### PR TITLE
fix: skip ASAR paths for binary resolution and update license to Apache-2.0

### DIFF
--- a/electron/__tests__/utils/binaryPaths.test.ts
+++ b/electron/__tests__/utils/binaryPaths.test.ts
@@ -34,6 +34,21 @@ describe('resolveWithAsarFallback', () => {
     expect(result).toBe('/usr/local/bin/ffmpeg');
   });
 
+  it('returns installer path when it already resolves to app.asar.unpacked (on-disk binary)', () => {
+    mockExistsSync.mockReturnValue(true);
+    const unpackedInstallerPath =
+      '/Applications/IngestAssistant.app/Contents/Resources/app.asar.unpacked/node_modules/@ffmpeg-installer/darwin-arm64/ffmpeg';
+
+    const result = resolveWithAsarFallback(
+      unpackedInstallerPath,
+      '@ffmpeg-installer',
+      'ffmpeg',
+      '/Applications/IngestAssistant.app/Contents/Resources/app.asar/electron'
+    );
+
+    expect(result).toBe(unpackedInstallerPath);
+  });
+
   it('skips installer path that contains app.asar even when fs.existsSync returns true', () => {
     // Electron patches fs so existsSync returns true for ASAR-internal paths,
     // but spawn() cannot execute from inside an ASAR archive.

--- a/electron/__tests__/utils/binaryPaths.test.ts
+++ b/electron/__tests__/utils/binaryPaths.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as os from 'os';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock('@ffmpeg-installer/ffmpeg', () => ({
+  default: { path: '/fake/node_modules/@ffmpeg-installer/darwin-arm64/ffmpeg' },
+}));
+
+vi.mock('@ffprobe-installer/ffprobe', () => ({
+  default: { path: '/fake/node_modules/@ffprobe-installer/darwin-arm64/ffprobe' },
+}));
+
+import * as fs from 'fs';
+import { resolveWithAsarFallback, getFfmpegPath, getFfprobePath } from '../../utils/binaryPaths';
+
+const mockExistsSync = vi.mocked(fs.existsSync);
+
+describe('resolveWithAsarFallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns installer path when it exists and is not inside app.asar', () => {
+    mockExistsSync.mockReturnValue(true);
+    const result = resolveWithAsarFallback(
+      '/usr/local/bin/ffmpeg',
+      '@ffmpeg-installer',
+      'ffmpeg',
+      '/usr/local/lib'
+    );
+    expect(result).toBe('/usr/local/bin/ffmpeg');
+  });
+
+  it('skips installer path that contains app.asar even when fs.existsSync returns true', () => {
+    // Electron patches fs so existsSync returns true for ASAR-internal paths,
+    // but spawn() cannot execute from inside an ASAR archive.
+    mockExistsSync.mockImplementation((p) => {
+      if (String(p).includes('app.asar.unpacked')) return true;
+      return true; // would also return true for the ASAR path — the guard must prevent this
+    });
+
+    const asarInstallerPath =
+      '/Applications/IngestAssistant.app/Contents/Resources/app.asar/node_modules/@ffmpeg-installer/darwin-arm64/ffmpeg';
+    const dirname =
+      '/Applications/IngestAssistant.app/Contents/Resources/app.asar/electron';
+
+    const result = resolveWithAsarFallback(
+      asarInstallerPath,
+      '@ffmpeg-installer',
+      'ffmpeg',
+      dirname
+    );
+
+    // Must resolve to the unpacked path, not the ASAR-internal installer path
+    expect(result).toContain('app.asar.unpacked');
+    expect(result).not.toBe(asarInstallerPath);
+  });
+
+  it('falls through to app.asar.unpacked when installer path contains app.asar and unpacked exists', () => {
+    mockExistsSync.mockImplementation((p) =>
+      String(p).includes('app.asar.unpacked')
+    );
+
+    const result = resolveWithAsarFallback(
+      '/path/to/app.asar/node_modules/@ffmpeg-installer/darwin-arm64/ffmpeg',
+      '@ffmpeg-installer',
+      'ffmpeg',
+      '/path/to/app.asar/electron'
+    );
+
+    const platform = os.platform() + '-' + os.arch();
+    expect(result).toBe(
+      `/path/to/app.asar.unpacked/node_modules/@ffmpeg-installer/${platform}/ffmpeg`
+    );
+  });
+
+  it('falls through to app.asar.unpacked when installer path is missing', () => {
+    mockExistsSync.mockImplementation((p) =>
+      String(p).includes('app.asar.unpacked')
+    );
+
+    const result = resolveWithAsarFallback(
+      '/does/not/exist/ffmpeg',
+      '@ffmpeg-installer',
+      'ffmpeg',
+      '/path/to/app.asar/electron'
+    );
+
+    expect(result).toContain('app.asar.unpacked');
+  });
+
+  it('throws when neither installer path nor unpacked path exists', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    expect(() =>
+      resolveWithAsarFallback(
+        '/does/not/exist/ffmpeg',
+        '@ffmpeg-installer',
+        'ffmpeg',
+        '/path/to/app.asar/electron'
+      )
+    ).toThrow('Could not find ffmpeg binary');
+  });
+
+  it('throws when not in ASAR context and installer path is missing', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    expect(() =>
+      resolveWithAsarFallback('/missing/ffmpeg', '@ffmpeg-installer', 'ffmpeg', '/dev/app')
+    ).toThrow('Could not find ffmpeg binary');
+  });
+});
+
+describe('getFfmpegPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a path when the mocked installer path exists', () => {
+    mockExistsSync.mockReturnValue(true);
+    expect(() => getFfmpegPath()).not.toThrow();
+    expect(getFfmpegPath()).toContain('ffmpeg');
+  });
+});
+
+describe('getFfprobePath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a path when the mocked installer path exists', () => {
+    mockExistsSync.mockReturnValue(true);
+    expect(() => getFfprobePath()).not.toThrow();
+    expect(getFfprobePath()).toContain('ffprobe');
+  });
+});

--- a/electron/utils/binaryPaths.ts
+++ b/electron/utils/binaryPaths.ts
@@ -25,8 +25,9 @@ export function resolveWithAsarFallback(
   // IMPORTANT: Electron patches fs to read inside ASAR archives, so
   // fs.existsSync() returns true for paths inside app.asar. But spawn()
   // cannot execute binaries from inside an ASAR — it needs a real file on
-  // disk. Skip installer paths that resolve inside app.asar.
-  if (!installerPath.includes('app.asar') && fs.existsSync(installerPath)) {
+  // disk. Skip installer paths that resolve inside app.asar (but NOT
+  // app.asar.unpacked, which is a real on-disk directory).
+  if (!(/(?:^|[/\\])app\.asar(?=[/\\]|$)/).test(installerPath) && fs.existsSync(installerPath)) {
     return installerPath;
   }
 

--- a/electron/utils/binaryPaths.ts
+++ b/electron/utils/binaryPaths.ts
@@ -22,7 +22,11 @@ export function resolveWithAsarFallback(
   dirname: string = __dirname
 ): string {
   // 1. Try the installer-provided path first
-  if (fs.existsSync(installerPath)) {
+  // IMPORTANT: Electron patches fs to read inside ASAR archives, so
+  // fs.existsSync() returns true for paths inside app.asar. But spawn()
+  // cannot execute binaries from inside an ASAR — it needs a real file on
+  // disk. Skip installer paths that resolve inside app.asar.
+  if (!installerPath.includes('app.asar') && fs.existsSync(installerPath)) {
     return installerPath;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ingest-assistant",
       "version": "3.0.0",
       "hasInstallScript": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.0",
         "@ffmpeg-installer/ffmpeg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6359,9 +6359,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -10520,9 +10520,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,7 +147,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -526,7 +525,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -550,7 +548,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1344,6 +1341,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1365,6 +1363,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1381,6 +1380,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1395,6 +1395,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3174,7 +3175,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3352,7 +3354,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3363,7 +3364,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3444,7 +3444,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -3799,7 +3798,6 @@
       "integrity": "sha512-sxSyJMaKp45zI0u+lHrPuZM1ZJQ8FaVD35k+UxVrha1yyvQ+TZuUYllUixwvQXlB7ixoDc7skf3lQPopZIvaQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.15",
         "fflate": "^0.8.2",
@@ -3863,7 +3861,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3924,7 +3921,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4371,7 +4367,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -5091,7 +5086,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5410,7 +5406,6 @@
       "integrity": "sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.0.12",
         "builder-util": "26.0.11",
@@ -5493,7 +5488,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-prop": {
       "version": "10.1.0",
@@ -5800,6 +5796,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -5820,6 +5817,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6031,7 +6029,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7396,7 +7393,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -7637,6 +7633,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8576,7 +8573,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8635,6 +8631,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -8652,6 +8649,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -8698,6 +8696,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8713,6 +8712,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8843,7 +8843,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8853,7 +8852,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8866,7 +8864,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -9067,6 +9066,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -9762,6 +9762,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -9825,6 +9826,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -10042,7 +10044,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10193,7 +10194,6 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -10284,7 +10284,6 @@
       "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.15",
         "@vitest/mocker": "4.0.15",
@@ -10525,7 +10524,6 @@
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10644,7 +10642,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,10 @@
     "react-window": "2.2.3",
     "zod": "^3.25.76"
   },
+  "overrides": {
+    "fast-uri": "3.1.2",
+    "ws": "8.21.0"
+  },
   "build": {
     "appId": "com.ingest-assistant",
     "productName": "Ingest Assistant",


### PR DESCRIPTION
## Summary

- **ASAR binary fix**: `resolveWithAsarFallback()` now skips any installer path that contains `app.asar`. Electron patches `fs.existsSync()` to return `true` for paths inside the ASAR archive, but `spawn()` cannot execute from within an ASAR — it needs a real file on disk. The guard ensures resolution falls through to the actual on-disk binary.
- **License update**: `package-lock.json` license field updated from `MIT` to `Apache-2.0`.

## Test plan

- [ ] Verify packaged app can locate and execute `ffmpeg`/`exiftool` binaries after fix
- [ ] Confirm no regression in dev mode (installer paths outside ASAR still resolve correctly)
- [ ] Check license field matches `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips `app.asar` paths (but allows `app.asar.unpacked`) when resolving binaries so packaged builds spawn real executables, fixing `ffmpeg`/`ffprobe`. Pins `fast-uri@3.1.2` and `ws@8.21.0` via `overrides` and regenerates the lockfile, adds unit tests for the ASAR guard and unpacked fallback, and updates `package-lock.json` license to `Apache-2.0`.

<sup>Written for commit cefb499e7d724ff4af28054a7249c13a43f25926. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/ingest-assistant/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

