### PR TITLE
fix: set publish:null in electron-builder config

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     ],
     "directories": {
       "output": "release"
-    }
+    },
+    "publish": null
   }
 }


### PR DESCRIPTION
## Summary

- Adds `"publish": null` to the `build` section of `package.json`

## Why

Without an explicit publish config, electron-builder auto-detects the GitHub repo as a publish provider and attempts to resolve it via `getPublishConfigsForUpdateInfo`. With no `GH_TOKEN` configured, this resolves to a null provider, crashing `updateInfoBuilder.ts` with `Cannot read properties of null (reading 'provider')`.

Setting `publish: null` short-circuits the detection at `getPublishConfigsForUpdateInfo` (returns `null` immediately) so `createUpdateInfoTasks` bails out early and no update-info files are generated.

Discovered during v3.0.1 binary build.

## Test plan

- [ ] `npm run package` completes without error and produces `.dmg` + `.zip` in `release/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `publish: null` in the `electron-builder` build config to disable publish auto-detection and prevent the null provider crash when no `GH_TOKEN` is set. Packaging now completes and skips update-info generation.

<sup>Written for commit c6c10a9705ad454c9229dcb3043083d519e7dade. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/ingest-assistant/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

