### PR TITLE
feat: copy .ingest-metadata.json to proxy output folder

### DIFF
--- a/electron/ipc/__tests__/proxyGenerationHandlers.test.ts
+++ b/electron/ipc/__tests__/proxyGenerationHandlers.test.ts
@@ -24,6 +24,12 @@ vi.mock('../../services/proxyOrchestrator', () => ({
   ProxyOrchestrator: MockProxyOrchestrator
 }))
 
+const mockCopyFile = vi.fn()
+vi.mock('fs/promises', () => ({
+  copyFile: (...args: unknown[]) => mockCopyFile(...args),
+  default: { copyFile: (...args: unknown[]) => mockCopyFile(...args) }
+}))
+
 describe('Proxy Generation IPC Handlers', () => {
   let mockWindow: any
   let mockOrchestrator: any
@@ -46,6 +52,8 @@ describe('Proxy Generation IPC Handlers', () => {
     mockOrchestrator = {
       executeJob: vi.fn()
     };
+
+    mockCopyFile.mockReset().mockResolvedValue(undefined)
 
     // Reset and configure mock constructor to return instance when called with 'new'
     MockProxyOrchestrator.mockReset().mockImplementation(function(this: any) {
@@ -270,6 +278,69 @@ describe('Proxy Generation IPC Handlers', () => {
       expect(result.success).toBe(false)
       expect(result.completedCount).toBe(1)
       expect(result.failedCount).toBe(1)
+    })
+  })
+
+  describe('Metadata Sidecar Copy', () => {
+    test('copies .ingest-metadata.json from rawVideoFolder to proxyOutputFolder', async () => {
+      // ARRANGE
+      mockOrchestrator.executeJob.mockResolvedValue({
+        success: true,
+        completedCount: 1,
+        failedCount: 0,
+        failedFiles: [],
+        verificationFailures: []
+      })
+
+      registerProxyGenerationHandlers(mockWindow)
+      const handler = (ipcMain.handle as any).mock.calls.find(
+        (call: any) => call[0] === 'proxy:generate'
+      )[1]
+
+      const validRequest = {
+        rawVideoFolder: '/valid/raw',
+        proxyOutputFolder: '/valid/output',
+        videoFilenames: ['video1.MOV']
+      }
+
+      // ACT
+      await handler({}, validRequest)
+
+      // ASSERT
+      expect(mockCopyFile).toHaveBeenCalledWith(
+        '/valid/raw/.ingest-metadata.json',
+        '/valid/output/.ingest-metadata.json'
+      )
+    })
+
+    test('tolerates missing source metadata file without failing proxy generation', async () => {
+      // ARRANGE
+      const expectedResult = {
+        success: true,
+        completedCount: 1,
+        failedCount: 0,
+        failedFiles: [],
+        verificationFailures: []
+      }
+      mockOrchestrator.executeJob.mockResolvedValue(expectedResult)
+      mockCopyFile.mockRejectedValue(Object.assign(new Error('not found'), { code: 'ENOENT' }))
+
+      registerProxyGenerationHandlers(mockWindow)
+      const handler = (ipcMain.handle as any).mock.calls.find(
+        (call: any) => call[0] === 'proxy:generate'
+      )[1]
+
+      const validRequest = {
+        rawVideoFolder: '/valid/raw',
+        proxyOutputFolder: '/valid/output',
+        videoFilenames: ['video1.MOV']
+      }
+
+      // ACT
+      const result = await handler({}, validRequest)
+
+      // ASSERT
+      expect(result).toEqual(expectedResult)
     })
   })
 

--- a/electron/ipc/__tests__/proxyGenerationHandlers.test.ts
+++ b/electron/ipc/__tests__/proxyGenerationHandlers.test.ts
@@ -324,6 +324,7 @@ describe('Proxy Generation IPC Handlers', () => {
       }
       mockOrchestrator.executeJob.mockResolvedValue(expectedResult)
       mockCopyFile.mockRejectedValue(Object.assign(new Error('not found'), { code: 'ENOENT' }))
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       registerProxyGenerationHandlers(mockWindow)
       const handler = (ipcMain.handle as any).mock.calls.find(
@@ -341,6 +342,79 @@ describe('Proxy Generation IPC Handlers', () => {
 
       // ASSERT
       expect(result).toEqual(expectedResult)
+      expect(mockCopyFile).toHaveBeenCalledWith(
+        '/valid/raw/.ingest-metadata.json',
+        '/valid/output/.ingest-metadata.json'
+      )
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+      consoleErrorSpy.mockRestore()
+    })
+
+    test('logs and continues when metadata copy fails for a reason other than missing file', async () => {
+      // ARRANGE
+      const expectedResult = {
+        success: true,
+        completedCount: 1,
+        failedCount: 0,
+        failedFiles: [],
+        verificationFailures: []
+      }
+      mockOrchestrator.executeJob.mockResolvedValue(expectedResult)
+      const permissionError = Object.assign(new Error('permission denied'), { code: 'EACCES' })
+      mockCopyFile.mockRejectedValue(permissionError)
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      registerProxyGenerationHandlers(mockWindow)
+      const handler = (ipcMain.handle as any).mock.calls.find(
+        (call: any) => call[0] === 'proxy:generate'
+      )[1]
+
+      const validRequest = {
+        rawVideoFolder: '/valid/raw',
+        proxyOutputFolder: '/valid/output',
+        videoFilenames: ['video1.MOV']
+      }
+
+      // ACT
+      const result = await handler({}, validRequest)
+
+      // ASSERT
+      expect(result).toEqual(expectedResult)
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to copy .ingest-metadata.json to proxy folder:',
+        permissionError
+      )
+
+      consoleErrorSpy.mockRestore()
+    })
+
+    test('skips the copy when rawVideoFolder and proxyOutputFolder are the same directory', async () => {
+      // ARRANGE
+      mockOrchestrator.executeJob.mockResolvedValue({
+        success: true,
+        completedCount: 1,
+        failedCount: 0,
+        failedFiles: [],
+        verificationFailures: []
+      })
+
+      registerProxyGenerationHandlers(mockWindow)
+      const handler = (ipcMain.handle as any).mock.calls.find(
+        (call: any) => call[0] === 'proxy:generate'
+      )[1]
+
+      const sameFolderRequest = {
+        rawVideoFolder: '/valid/raw',
+        proxyOutputFolder: '/valid/raw',
+        videoFilenames: ['video1.MOV']
+      }
+
+      // ACT
+      await handler({}, sameFolderRequest)
+
+      // ASSERT
+      expect(mockCopyFile).not.toHaveBeenCalled()
     })
   })
 

--- a/electron/ipc/proxyGenerationHandlers.ts
+++ b/electron/ipc/proxyGenerationHandlers.ts
@@ -116,14 +116,15 @@ export function registerProxyGenerationHandlers(mainWindow: BrowserWindow) {
       )
 
       // Copy metadata sidecar to proxy destination (best-effort; missing source is not an error)
-      try {
-        await copyFile(
-          path.join(validated.rawVideoFolder, METADATA_FILENAME),
-          path.join(validated.proxyOutputFolder, METADATA_FILENAME)
-        )
-      } catch (copyError: unknown) {
-        if ((copyError as NodeJS.ErrnoException)?.code !== 'ENOENT') {
-          console.error('Failed to copy .ingest-metadata.json to proxy folder:', copyError)
+      const srcMetadataPath = path.resolve(validated.rawVideoFolder, METADATA_FILENAME)
+      const destMetadataPath = path.resolve(validated.proxyOutputFolder, METADATA_FILENAME)
+      if (srcMetadataPath !== destMetadataPath) {
+        try {
+          await copyFile(srcMetadataPath, destMetadataPath)
+        } catch (copyError: unknown) {
+          if ((copyError as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+            console.error('Failed to copy .ingest-metadata.json to proxy folder:', copyError)
+          }
         }
       }
 

--- a/electron/ipc/proxyGenerationHandlers.ts
+++ b/electron/ipc/proxyGenerationHandlers.ts
@@ -28,6 +28,9 @@ import {
   ProxyProgressEvent
 } from '../services/proxyOrchestrator'
 import * as path from 'path'
+import { copyFile } from 'fs/promises'
+
+const METADATA_FILENAME = '.ingest-metadata.json'
 
 /**
  * Validation schema for proxy generation request
@@ -111,6 +114,18 @@ export function registerProxyGenerationHandlers(mainWindow: BrowserWindow) {
       const rawVideoPaths = validated.videoFilenames.map(filename =>
         path.join(validated.rawVideoFolder, filename)
       )
+
+      // Copy metadata sidecar to proxy destination (best-effort; missing source is not an error)
+      try {
+        await copyFile(
+          path.join(validated.rawVideoFolder, METADATA_FILENAME),
+          path.join(validated.proxyOutputFolder, METADATA_FILENAME)
+        )
+      } catch (copyError: unknown) {
+        if ((copyError as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+          console.error('Failed to copy .ingest-metadata.json to proxy folder:', copyError)
+        }
+      }
 
       // Get orchestrator instance
       const orch = getOrchestrator()


### PR DESCRIPTION
## Summary
- When generating proxies, the metadata sidecar (`.ingest-metadata.json`) is now copied from the raw video folder to the chosen proxy output folder alongside the transcoded proxies.
- Copy is best-effort: a missing source file (ENOENT) does not fail proxy generation; other copy errors are logged but don't block the batch.

## Test plan
- [x] Added failing tests first (TDD RED): copy invoked with correct source/dest paths; ENOENT tolerated without failing the batch
- [x] `npx vitest run electron/ipc/__tests__/proxyGenerationHandlers.test.ts` — 12/12 passing
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm test -- --run` — 1382 passed, 15 pre-existing skips, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Copies the `.ingest-metadata.json` sidecar from the raw video folder to the proxy output folder so metadata travels with proxies. The copy is best-effort and safe: missing source is ignored, other errors are logged, and self-copy is skipped when source and destination are the same.

- **New Features**
  - Copy `.ingest-metadata.json` to the proxy folder; skip when paths resolve to the same directory.
  - Tolerate `ENOENT` (missing source); log other copy errors without failing proxy generation.
  - Tests cover correct paths, ENOENT tolerance, non-ENOENT logging, and the self-copy guard.

<sup>Written for commit 363b75c8577f6b2902d5be4c23169b824a108b62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/ingest-assistant/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

