### PR TITLE
Fix/cfex fuji card content detection

### DIFF
--- a/electron/services/__tests__/cfexAutoDetect.test.ts
+++ b/electron/services/__tests__/cfexAutoDetect.test.ts
@@ -221,6 +221,93 @@ describe('CfexAutoDetect Service', () => {
     })
   })
 
+  describe('Fuji Card Detection by Structure (Linux)', () => {
+    beforeEach(() => {
+      vi.mocked(os.platform).mockReturnValue('linux')
+      vi.mocked(os.homedir).mockReturnValue('/home/testuser')
+    })
+
+    it('should detect card mounted as "disk" when DCIM/100_FUJI exists', async () => {
+      vi.mocked(fs.readdir).mockImplementation((p: PathLike) => {
+        if (p === '/media/testuser/') return Promise.resolve(['disk', 'backup-drive'] as any)
+        return Promise.resolve([] as any)
+      })
+      vi.mocked(fs.stat).mockImplementation((p: PathLike) => {
+        if (p.toString() === '/media/testuser/disk/DCIM/100_FUJI') return Promise.resolve({} as any)
+        return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+      })
+
+      const cards = await autoDetect.detectCfexCards()
+
+      expect(cards).toContain('/media/testuser/disk')
+      expect(cards).not.toContain('/media/testuser/backup-drive')
+    })
+
+    it('should detect card mounted as "disk1" when stale "disk" directory exists', async () => {
+      vi.mocked(fs.readdir).mockImplementation((p: PathLike) => {
+        if (p === '/media/testuser/') return Promise.resolve(['disk', 'disk1'] as any)
+        return Promise.resolve([] as any)
+      })
+      vi.mocked(fs.stat).mockImplementation((p: PathLike) => {
+        // disk is a stale empty directory; disk1 is the actual card
+        if (p.toString() === '/media/testuser/disk1/DCIM/100_FUJI') return Promise.resolve({} as any)
+        return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+      })
+
+      const cards = await autoDetect.detectCfexCards()
+
+      expect(cards).toContain('/media/testuser/disk1')
+      expect(cards).not.toContain('/media/testuser/disk')
+    })
+
+    it('should detect card regardless of volume label', async () => {
+      vi.mocked(fs.readdir).mockImplementation((p: PathLike) => {
+        if (p === '/media/testuser/') return Promise.resolve(['MY_CARD', 'disk3', 'external-hdd'] as any)
+        return Promise.resolve([] as any)
+      })
+      vi.mocked(fs.stat).mockImplementation((p: PathLike) => {
+        if (p.toString() === '/media/testuser/disk3/DCIM/100_FUJI') return Promise.resolve({} as any)
+        return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+      })
+
+      const cards = await autoDetect.detectCfexCards()
+
+      expect(cards).toContain('/media/testuser/disk3')
+      expect(cards).not.toContain('/media/testuser/MY_CARD')
+      expect(cards).not.toContain('/media/testuser/external-hdd')
+    })
+
+    it('should check /run/media as well as /media for content-based detection', async () => {
+      vi.mocked(fs.readdir).mockImplementation((p: PathLike) => {
+        if (p === '/media/testuser/') return Promise.resolve([] as any)
+        if (p === '/run/media/testuser/') return Promise.resolve(['disk'] as any)
+        return Promise.resolve([] as any)
+      })
+      vi.mocked(fs.stat).mockImplementation((p: PathLike) => {
+        if (p.toString() === '/run/media/testuser/disk/DCIM/100_FUJI') return Promise.resolve({} as any)
+        return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+      })
+
+      const cards = await autoDetect.detectCfexCards()
+
+      expect(cards).toContain('/run/media/testuser/disk')
+    })
+
+    it('should return empty when no mounted directory has DCIM/100_FUJI', async () => {
+      vi.mocked(fs.readdir).mockImplementation((p: PathLike) => {
+        if (p === '/media/testuser/') return Promise.resolve(['disk', 'external-hdd'] as any)
+        return Promise.resolve([] as any)
+      })
+      vi.mocked(fs.stat).mockImplementation((_p: PathLike) => {
+        return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+      })
+
+      const cards = await autoDetect.detectCfexCards()
+
+      expect(cards).toEqual([])
+    })
+  })
+
   describe('Card Selection Logic', () => {
     it('should identify single card for auto-population', async () => {
       // ARRANGE: Mock single card detection

--- a/electron/services/__tests__/cfexAutoDetect.test.ts
+++ b/electron/services/__tests__/cfexAutoDetect.test.ts
@@ -139,12 +139,17 @@ describe('CfexAutoDetect Service', () => {
     })
 
     it('should detect CFEx cards in /media/$USER/', async () => {
-      // ARRANGE: Mock /media/testuser/ directory
+      // ARRANGE: content-based detection — the mount is detected because its
+      // DCIM contains an NNN_FUJI folder, not because of its label.
       vi.mocked(fs.readdir).mockImplementation((path: PathLike) => {
-        if (path === '/media/testuser/') {
+        const s = path.toString()
+        if (s === '/media/testuser/') {
           return Promise.resolve(['CFEx', 'other-drive'] as any)
         }
-        return Promise.resolve([])
+        if (s === '/media/testuser/CFEx/DCIM') {
+          return Promise.resolve([{ name: '100_FUJI', isDirectory: () => true }] as any)
+        }
+        return Promise.resolve([] as any)
       })
 
       // ACT
@@ -152,18 +157,23 @@ describe('CfexAutoDetect Service', () => {
 
       // ASSERT
       expect(cards).toContain('/media/testuser/CFEx')
+      expect(cards).not.toContain('/media/testuser/other-drive')
     })
 
     it('should detect CFEx cards in /run/media/$USER/', async () => {
-      // ARRANGE: Mock /run/media/testuser/ directory
+      // ARRANGE: content-based detection on the /run/media location
       vi.mocked(fs.readdir).mockImplementation((path: PathLike) => {
-        if (path === '/run/media/testuser/') {
+        const s = path.toString()
+        if (s === '/run/media/testuser/') {
           return Promise.resolve(['CFEx'] as any)
         }
-        if (path === '/media/testuser/') {
+        if (s === '/media/testuser/') {
           return Promise.resolve([] as any)
         }
-        return Promise.resolve([])
+        if (s === '/run/media/testuser/CFEx/DCIM') {
+          return Promise.resolve([{ name: '100_FUJI', isDirectory: () => true }] as any)
+        }
+        return Promise.resolve([] as any)
       })
 
       // ACT

--- a/electron/services/__tests__/cfexAutoDetect.test.ts
+++ b/electron/services/__tests__/cfexAutoDetect.test.ts
@@ -227,14 +227,19 @@ describe('CfexAutoDetect Service', () => {
       vi.mocked(os.homedir).mockReturnValue('/home/testuser')
     })
 
-    it('should detect card mounted as "disk" when DCIM/100_FUJI exists', async () => {
+    // Dirent-like helper for withFileTypes readdir mocks
+    const dirent = (name: string, isDir = true) => ({ name, isDirectory: () => isDir }) as any
+
+    it('should detect card mounted as "disk" when DCIM contains an NNN_FUJI folder', async () => {
       vi.mocked(fs.readdir).mockImplementation((p: PathLike) => {
-        if (p === '/media/testuser/') return Promise.resolve(['disk', 'backup-drive'] as any)
+        const s = p.toString()
+        if (s === '/media/testuser/') return Promise.resolve(['disk', 'backup-drive'] as any)
+        if (s === '/media/testuser/disk/DCIM') return Promise.resolve([dirent('100_FUJI')] as any)
+        // backup-drive has no DCIM directory
+        if (s === '/media/testuser/backup-drive/DCIM') {
+          return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+        }
         return Promise.resolve([] as any)
-      })
-      vi.mocked(fs.stat).mockImplementation((p: PathLike) => {
-        if (p.toString() === '/media/testuser/disk/DCIM/100_FUJI') return Promise.resolve({} as any)
-        return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
       })
 
       const cards = await autoDetect.detectCfexCards()
@@ -245,13 +250,12 @@ describe('CfexAutoDetect Service', () => {
 
     it('should detect card mounted as "disk1" when stale "disk" directory exists', async () => {
       vi.mocked(fs.readdir).mockImplementation((p: PathLike) => {
-        if (p === '/media/testuser/') return Promise.resolve(['disk', 'disk1'] as any)
+        const s = p.toString()
+        if (s === '/media/testuser/') return Promise.resolve(['disk', 'disk1'] as any)
+        // disk is a stale empty directory (empty DCIM); disk1 is the actual card
+        if (s === '/media/testuser/disk/DCIM') return Promise.resolve([] as any)
+        if (s === '/media/testuser/disk1/DCIM') return Promise.resolve([dirent('100_FUJI')] as any)
         return Promise.resolve([] as any)
-      })
-      vi.mocked(fs.stat).mockImplementation((p: PathLike) => {
-        // disk is a stale empty directory; disk1 is the actual card
-        if (p.toString() === '/media/testuser/disk1/DCIM/100_FUJI') return Promise.resolve({} as any)
-        return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
       })
 
       const cards = await autoDetect.detectCfexCards()
@@ -262,12 +266,10 @@ describe('CfexAutoDetect Service', () => {
 
     it('should detect card regardless of volume label', async () => {
       vi.mocked(fs.readdir).mockImplementation((p: PathLike) => {
-        if (p === '/media/testuser/') return Promise.resolve(['MY_CARD', 'disk3', 'external-hdd'] as any)
+        const s = p.toString()
+        if (s === '/media/testuser/') return Promise.resolve(['MY_CARD', 'disk3', 'external-hdd'] as any)
+        if (s === '/media/testuser/disk3/DCIM') return Promise.resolve([dirent('100_FUJI')] as any)
         return Promise.resolve([] as any)
-      })
-      vi.mocked(fs.stat).mockImplementation((p: PathLike) => {
-        if (p.toString() === '/media/testuser/disk3/DCIM/100_FUJI') return Promise.resolve({} as any)
-        return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
       })
 
       const cards = await autoDetect.detectCfexCards()
@@ -279,13 +281,11 @@ describe('CfexAutoDetect Service', () => {
 
     it('should check /run/media as well as /media for content-based detection', async () => {
       vi.mocked(fs.readdir).mockImplementation((p: PathLike) => {
-        if (p === '/media/testuser/') return Promise.resolve([] as any)
-        if (p === '/run/media/testuser/') return Promise.resolve(['disk'] as any)
+        const s = p.toString()
+        if (s === '/media/testuser/') return Promise.resolve([] as any)
+        if (s === '/run/media/testuser/') return Promise.resolve(['disk'] as any)
+        if (s === '/run/media/testuser/disk/DCIM') return Promise.resolve([dirent('100_FUJI')] as any)
         return Promise.resolve([] as any)
-      })
-      vi.mocked(fs.stat).mockImplementation((p: PathLike) => {
-        if (p.toString() === '/run/media/testuser/disk/DCIM/100_FUJI') return Promise.resolve({} as any)
-        return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
       })
 
       const cards = await autoDetect.detectCfexCards()
@@ -293,18 +293,66 @@ describe('CfexAutoDetect Service', () => {
       expect(cards).toContain('/run/media/testuser/disk')
     })
 
-    it('should return empty when no mounted directory has DCIM/100_FUJI', async () => {
+    it('should return empty when no mounted directory has an NNN_FUJI folder', async () => {
       vi.mocked(fs.readdir).mockImplementation((p: PathLike) => {
-        if (p === '/media/testuser/') return Promise.resolve(['disk', 'external-hdd'] as any)
-        return Promise.resolve([] as any)
-      })
-      vi.mocked(fs.stat).mockImplementation((_p: PathLike) => {
+        const s = p.toString()
+        if (s === '/media/testuser/') return Promise.resolve(['disk', 'external-hdd'] as any)
+        // No DCIM directories anywhere
         return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
       })
 
       const cards = await autoDetect.detectCfexCards()
 
       expect(cards).toEqual([])
+    })
+
+    // BLOCKING P1: DCF folder rollover — 100_FUJI → 101_FUJI → 102_FUJI ...
+    // A reused/high-count card may have NO 100_FUJI folder at all.
+    it('should detect a card whose ONLY DCIM subfolder is 101_FUJI (rollover)', async () => {
+      vi.mocked(fs.readdir).mockImplementation((p: PathLike) => {
+        const s = p.toString()
+        if (s === '/media/testuser/') return Promise.resolve(['disk'] as any)
+        if (s === '/media/testuser/disk/DCIM') return Promise.resolve([dirent('101_FUJI')] as any)
+        return Promise.resolve([] as any)
+      })
+
+      const cards = await autoDetect.detectCfexCards()
+
+      expect(cards).toContain('/media/testuser/disk')
+    })
+
+    // BLOCKING P2: a plain FILE named 100_FUJI must NOT count as a match.
+    it('should NOT detect when 100_FUJI is a regular file, not a directory', async () => {
+      vi.mocked(fs.readdir).mockImplementation((p: PathLike) => {
+        const s = p.toString()
+        if (s === '/media/testuser/') return Promise.resolve(['disk'] as any)
+        // 100_FUJI present but as a regular file (isDirectory() === false)
+        if (s === '/media/testuser/disk/DCIM') return Promise.resolve([dirent('100_FUJI', false)] as any)
+        return Promise.resolve([] as any)
+      })
+
+      const cards = await autoDetect.detectCfexCards()
+
+      expect(cards).not.toContain('/media/testuser/disk')
+      expect(cards).toEqual([])
+    })
+
+    // RECOMMENDED: Promise.allSettled hardening — a failing media root must not
+    // discard a valid card found on the other root.
+    it('should still return a valid card when one media root rejects EACCES', async () => {
+      vi.mocked(fs.readdir).mockImplementation((p: PathLike) => {
+        const s = p.toString()
+        if (s === '/media/testuser/') {
+          return Promise.reject(Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' }))
+        }
+        if (s === '/run/media/testuser/') return Promise.resolve(['disk'] as any)
+        if (s === '/run/media/testuser/disk/DCIM') return Promise.resolve([dirent('100_FUJI')] as any)
+        return Promise.resolve([] as any)
+      })
+
+      const cards = await autoDetect.detectCfexCards()
+
+      expect(cards).toContain('/run/media/testuser/disk')
     })
   })
 

--- a/electron/services/cfexAutoDetect.ts
+++ b/electron/services/cfexAutoDetect.ts
@@ -48,12 +48,26 @@ export class CfexAutoDetect {
         const mediaPath = `/media/${username}/`
         const runMediaPath = `/run/media/${username}/`
 
-        const results = await Promise.all([
+        // Use allSettled so a failure (EACCES/ETIMEDOUT) on one media root
+        // cannot discard cards already found on the other root.
+        const settled = await Promise.allSettled([
           this.detectFujiCardsWithTimeout(mediaPath, 10000),
           this.detectFujiCardsWithTimeout(runMediaPath, 10000)
         ])
 
-        return [...results[0], ...results[1]]
+        const cards: string[] = []
+        for (const outcome of settled) {
+          if (outcome.status === 'fulfilled') {
+            cards.push(...outcome.value)
+          } else {
+            const reason = outcome.reason
+            console.warn(
+              `CFEx Fuji scan failed for a media root: ${reason instanceof Error ? reason.message : String(reason)}`
+            )
+          }
+        }
+
+        return cards
       }
 
       return []
@@ -233,9 +247,20 @@ export class CfexAutoDetect {
   }
 
   /**
-   * Scan a directory for Fuji CFEx cards by checking for DCIM/100_FUJI structure.
-   * Returns mount paths where the Fuji directory structure is present,
-   * regardless of the volume label (handles "disk", "disk1", "NO NAME", etc.).
+   * Matches a Fujifilm DCF image folder name.
+   *
+   * DCF folders roll over as they fill: 100_FUJI → 101_FUJI → 102_FUJI ... (at
+   * 999 files, and continuously across camera bodies). Hard-coding 100_FUJI
+   * silently false-negatives the common reused/high-count card, so we match ANY
+   * three-digit NNN_FUJI folder.
+   */
+  private static readonly FUJI_DCF_FOLDER = /^\d{3}_FUJI$/
+
+  /**
+   * Scan a directory for Fuji CFEx cards by checking the DCIM folder for any
+   * NNN_FUJI subdirectory. Returns mount paths where the Fuji directory
+   * structure is present, regardless of the volume label (handles "disk",
+   * "disk1", "NO NAME", etc.).
    */
   private async scanForFujiCards(dirPath: string): Promise<string[]> {
     try {
@@ -243,11 +268,19 @@ export class CfexAutoDetect {
       const results = await Promise.all(
         entries.map(async (entry) => {
           const mountPath = path.join(dirPath, entry)
-          const fujiPath = path.join(mountPath, 'DCIM', '100_FUJI')
+          const dcimPath = path.join(mountPath, 'DCIM')
           try {
-            await fs.stat(fujiPath)
-            return mountPath
+            // withFileTypes lets us both enumerate NNN_FUJI folders (rollover)
+            // and guard that the match is a directory, not a regular file.
+            const dcimEntries = await fs.readdir(dcimPath, { withFileTypes: true })
+            const hasFujiFolder = dcimEntries.some(
+              (dirent) =>
+                dirent.isDirectory() &&
+                CfexAutoDetect.FUJI_DCF_FOLDER.test(dirent.name)
+            )
+            return hasFujiFolder ? mountPath : null
           } catch {
+            // No DCIM directory (or unreadable) → not a detectable Fuji card.
             return null
           }
         })

--- a/electron/services/cfexAutoDetect.ts
+++ b/electron/services/cfexAutoDetect.ts
@@ -41,14 +41,16 @@ export class CfexAutoDetect {
         // macOS: Scan /Volumes/ for "NO NAME" directories with timeout
         return await this.detectWithTimeout('/Volumes/', ['NO NAME'], 10000)
       } else if (platform === 'linux') {
-        // Ubuntu: Scan both /media/$USER/ and /run/media/$USER/ with timeouts
+        // Ubuntu: Scan both /media/$USER/ and /run/media/$USER/.
+        // Use content-based detection (DCIM/100_FUJI presence) rather than
+        // volume label matching — Fuji cards mount as "disk", "disk1", etc.
         const username = path.basename(os.homedir())
         const mediaPath = `/media/${username}/`
         const runMediaPath = `/run/media/${username}/`
 
         const results = await Promise.all([
-          this.detectWithTimeout(mediaPath, ['CFEx'], 10000),
-          this.detectWithTimeout(runMediaPath, ['CFEx'], 10000)
+          this.detectFujiCardsWithTimeout(mediaPath, 10000),
+          this.detectFujiCardsWithTimeout(runMediaPath, 10000)
         ])
 
         return [...results[0], ...results[1]]
@@ -202,6 +204,75 @@ export class CfexAutoDetect {
       // Unexpected errors: Log for debugging
       console.warn(`Unexpected error checking path ${checkPath}: ${error instanceof Error ? error.message : String(error)}`)
       return false
+    }
+  }
+
+  /**
+   * Detect Fuji CFEx cards in a directory using content-based detection with timeout.
+   * Checks for DCIM/100_FUJI presence rather than matching volume label.
+   */
+  private async detectFujiCardsWithTimeout(dirPath: string, timeoutMs: number): Promise<string[]> {
+    return new Promise<string[]>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(Object.assign(
+          new Error(`Volume scan timeout: ${dirPath}`),
+          { code: 'ETIMEDOUT' }
+        ))
+      }, timeoutMs)
+
+      this.scanForFujiCards(dirPath)
+        .then(result => {
+          clearTimeout(timer)
+          resolve(result)
+        })
+        .catch(err => {
+          clearTimeout(timer)
+          reject(err)
+        })
+    })
+  }
+
+  /**
+   * Scan a directory for Fuji CFEx cards by checking for DCIM/100_FUJI structure.
+   * Returns mount paths where the Fuji directory structure is present,
+   * regardless of the volume label (handles "disk", "disk1", "NO NAME", etc.).
+   */
+  private async scanForFujiCards(dirPath: string): Promise<string[]> {
+    try {
+      const entries = await fs.readdir(dirPath)
+      const results = await Promise.all(
+        entries.map(async (entry) => {
+          const mountPath = path.join(dirPath, entry)
+          const fujiPath = path.join(mountPath, 'DCIM', '100_FUJI')
+          try {
+            await fs.stat(fujiPath)
+            return mountPath
+          } catch {
+            return null
+          }
+        })
+      )
+      return results.filter((p): p is string => p !== null)
+    } catch (error: unknown) {
+      const nodeError = error as NodeJS.ErrnoException
+
+      if (nodeError?.code === 'EACCES') {
+        throw Object.assign(
+          new Error(`Permission denied scanning ${dirPath}. Check volume mount permissions.`),
+          { code: 'EACCES' }
+        )
+      }
+
+      if (nodeError?.code === 'ENOENT') {
+        return []
+      }
+
+      if (nodeError?.code === 'EIO') {
+        console.warn(`I/O error scanning ${dirPath}`)
+        return []
+      }
+
+      throw error
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ingest-assistant",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ingest-assistant",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -147,6 +147,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -525,6 +526,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -548,6 +550,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1341,7 +1344,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1363,7 +1365,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1380,7 +1381,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1395,7 +1395,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3175,8 +3174,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3354,6 +3352,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3364,6 +3363,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3444,6 +3444,7 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -3798,6 +3799,7 @@
       "integrity": "sha512-sxSyJMaKp45zI0u+lHrPuZM1ZJQ8FaVD35k+UxVrha1yyvQ+TZuUYllUixwvQXlB7ixoDc7skf3lQPopZIvaQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.15",
         "fflate": "^0.8.2",
@@ -3861,6 +3863,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3921,6 +3924,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4367,6 +4371,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -5086,8 +5091,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5406,6 +5410,7 @@
       "integrity": "sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.0.12",
         "builder-util": "26.0.11",
@@ -5488,8 +5493,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dot-prop": {
       "version": "10.1.0",
@@ -5796,7 +5800,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -5817,7 +5820,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6029,6 +6031,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7393,6 +7396,7 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -7633,7 +7637,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8573,6 +8576,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8631,7 +8635,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -8649,7 +8652,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -8696,7 +8698,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8712,7 +8713,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8843,6 +8843,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8852,6 +8853,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8864,8 +8866,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -9066,7 +9067,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -9762,7 +9762,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -9826,7 +9825,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -10044,6 +10042,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10194,6 +10193,7 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -10284,6 +10284,7 @@
       "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.15",
         "@vitest/mocker": "4.0.15",
@@ -10524,6 +10525,7 @@
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10642,6 +10644,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Fuji CFEx detection on Linux by checking mounted volumes under /media and /run/media for DCIM/NNN_FUJI folders instead of volume labels. Adds tests for rollover folders, "disk"/stale mounts, file-guard, and EACCES resilience.

- **Bug Fixes**
  - Linux: content-based scan of `/media/$USER` and `/run/media/$USER`; matches any NNN_FUJI dir (withFileTypes), ignores files, uses allSettled so one root error doesn’t hide the other; timeouts retained.
  - macOS unchanged (still scans `/Volumes/` for "NO NAME").

<sup>Written for commit f2f24bb292ca1838035c9b805a80295a42e83318. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/ingest-assistant/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

