### PR TITLE
chore: release v3.0.2 — CFEx Fuji card detection fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.0.2] - 2026-07-02
+
+### Fixed
+
+- CFEx auto-detect on Linux now identifies Fuji cards by `DCIM/NNN_FUJI` directory structure rather than volume label — cards that mount as `disk`, `disk1`, or any other label are correctly detected
+- Stale empty mount point directories (e.g. a leftover `disk` directory after the reader was remounted as `disk1`) no longer block card detection
+
+---
+
 ## [3.0.1] - 2026-06-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ingest-assistant",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "AI-powered media file ingestion and metadata assistant with keyboard shortcuts, virtual scrolling, and enhanced security",
   "main": "dist/electron/electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump version `3.0.1` → `3.0.2`
- Add `[3.0.2]` CHANGELOG entry documenting the Fuji card detection fix

## What's in this release

The CFEx auto-detect fix (already merged in #168) is the only change since 3.0.1. This PR cuts the release so a new installable build can be produced.

**Fix:** On Linux, CFEx cards are now detected by the presence of `DCIM/NNN_FUJI` on the mounted volume rather than by volume label. Cards that mount as `disk`, `disk1`, or any other label are correctly identified. Stale empty mount point directories no longer block detection.

## Test plan

- [x] `npm run lint` — 0 errors (7 pre-existing warnings)
- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 1392/1392 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v3.0.2 to ship the CFEx Fuji card auto-detect fix on Linux. Detection now uses the `DCIM/NNN_FUJI` directory instead of volume labels, so cards mounted as `disk`, `disk1`, or any label are found.

- **Bug Fixes**
  - Detect Fuji cards by `DCIM/NNN_FUJI` directory structure, not volume label.
  - Ignore stale empty mount directories that previously blocked detection.

<sup>Written for commit ee253fffbf2a5e09e92cd58672ea183a0fd948f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/ingest-assistant/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

