### PR TITLE
fix(security): resolve HIGH npm audit vulnerabilities blocking CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ingest-assistant",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ingest-assistant",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -15,7 +15,7 @@
         "@ffprobe-installer/ffprobe": "^2.1.2",
         "dotenv": "^17.2.3",
         "electron-store": "^11.0.2",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.0",
         "keytar": "^7.9.0",
         "openai": "^6.9.1",
         "react": "^19.2.1",
@@ -147,7 +147,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -526,7 +525,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -550,7 +548,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1344,6 +1341,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1365,6 +1363,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1381,6 +1380,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1395,6 +1395,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3174,7 +3175,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3352,7 +3354,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3363,7 +3364,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3444,7 +3444,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -3799,7 +3798,6 @@
       "integrity": "sha512-sxSyJMaKp45zI0u+lHrPuZM1ZJQ8FaVD35k+UxVrha1yyvQ+TZuUYllUixwvQXlB7ixoDc7skf3lQPopZIvaQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.15",
         "fflate": "^0.8.2",
@@ -3863,7 +3861,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3924,7 +3921,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3954,9 +3950,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -4371,7 +4367,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4984,9 +4979,9 @@
       }
     },
     "node_modules/conf/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -5091,7 +5086,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5410,7 +5406,6 @@
       "integrity": "sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.0.12",
         "builder-util": "26.0.11",
@@ -5493,7 +5488,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-prop": {
       "version": "10.1.0",
@@ -5800,6 +5796,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -5820,6 +5817,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6031,7 +6029,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6359,9 +6356,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -7379,9 +7376,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7396,7 +7403,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -7637,6 +7643,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8576,7 +8583,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8635,6 +8641,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -8652,6 +8659,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -8698,6 +8706,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8713,6 +8722,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8843,7 +8853,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8853,7 +8862,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8866,7 +8874,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -9067,6 +9076,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -9762,6 +9772,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -9825,6 +9836,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -10042,7 +10054,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10193,7 +10204,6 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -10284,7 +10294,6 @@
       "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.15",
         "@vitest/mocker": "4.0.15",
@@ -10525,7 +10534,6 @@
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10644,7 +10652,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@ffprobe-installer/ffprobe": "^2.1.2",
     "dotenv": "^17.2.3",
     "electron-store": "^11.0.2",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.3.0",
     "keytar": "^7.9.0",
     "openai": "^6.9.1",
     "react": "^19.2.1",
@@ -73,8 +73,14 @@
     "zod": "^3.25.76"
   },
   "overrides": {
-    "fast-uri": "3.1.2",
-    "ws": "8.21.0"
+    "fast-uri": "3.1.4",
+    "ws": "8.21.0",
+    "ajv-formats": {
+      "ajv": "^8.18.0"
+    },
+    "conf": {
+      "ajv": "^8.18.0"
+    }
   },
   "build": {
     "appId": "com.ingest-assistant",


### PR DESCRIPTION
## Summary

The "Security Scanning & Compliance" CI gate runs `npm audit --production --audit-level=high --json` and fails on any HIGH/CRITICAL finding. It currently blocks all three open PRs (#172, #173, #174) with 3 findings in the production tree:

- `fast-uri` 3.0.0 - 3.1.3 (HIGH) — GHSA-v2hh-gcrm-f6hx, GHSA-4c8g-83qw-93j6 (host confusion)
- `js-yaml` 4.0.0 - 4.2.0 (HIGH) — GHSA-h67p-54hq-rp68, GHSA-52cp-r559-cp3m (quadratic-complexity DoS)
- `ajv` 7.0.0-alpha.0 - 8.17.1 (**HIGH**, not the advisory-page "moderate" — `npm audit` scores it HIGH for this tree) — GHSA-2g4f-4pwh-qvx6 (ReDoS via `$data`)

None of the three open PRs introduced this — it's a pre-existing condition on `main`.

## Why the previous fast-uri override was the blocker

`package.json` already carried `"overrides": { "fast-uri": "3.1.2", ... }`, added during a prior release to close an *earlier* fast-uri advisory. That pin (3.1.2) now falls **inside** the new vulnerable range (3.0.0 - 3.1.3), so the override was actively holding the vulnerable version in place and `npm audit fix` could not move past it.

## Changes

- `overrides.fast-uri`: `3.1.2` → `3.1.4` (patched)
- `dependencies.js-yaml`: `^4.1.0` → `^4.3.0` (patched, stays on the 4.x line — 5.x is a major bump and out of scope)
- `overrides`: added **nested** overrides scoping ajv to 8.18.0+ only under `ajv-formats` and `conf` (the two paths that pull in vulnerable `ajv@8.17.1` via `electron-store → conf` and `ajv-formats`), rather than a blanket `"ajv"` override. The top-level `ajv@6.12.6` is used by `eslint`, `@develar/schema-utils`, and `dmg-license` — a blanket override would have forced an unrelated major-version bump (6→8) onto lint/build tooling. Scoped nested overrides avoid that.
- `package-lock.json` regenerated to reflect the above (also picks up a stale `version` field correction, 3.0.1→3.0.2, matching `package.json`; the scattered `"peer": true` metadata diffs are npm lockfile-format noise from regenerating with the current npm version, not package version changes).

I included the ajv fix (offered as optional in scope) because `npm audit` actually reports it as **HIGH** severity for this dependency tree, not moderate — so it's required, not optional, to reach 0 high/critical.

## Ripple analysis

- `js-yaml` is a direct production dependency consumed by `electron/services/configManager.ts` and `electron/scripts/test-structured-analysis.ts`. Both use only `load`/`dump`-style APIs that are stable across the 4.x line — no breaking surface between 4.1 and 4.3.
- `fast-uri`/`ajv` sit under `electron-store → conf → ajv` (config/credential persistence for the app's multi-AI-provider routing). Verified via `package-lock.json` that only `ajv-formats` and `conf` resolve the vulnerable nested `ajv@8.17.1` — the fix is scoped to exactly those two paths.

## Environment note: shared node_modules symlink

This worktree's `node_modules` is a symlink to the main repo's `node_modules` (`/Volumes/HestAI-Projects/ingest-assistant/node_modules`), shared across worktrees/PRs. Running `npm install`/`npm ci` directly here would trigger the `postinstall` script (`electron-rebuild -f -w keytar`), mutating that shared install/native build.

To avoid this, I:
1. Regenerated `package-lock.json` via `npm install --package-lock-only` in the worktree (lockfile-only; confirmed no writes into the shared `node_modules` — `postinstall` did fire but failed harmlessly with `electron-rebuild: command not found` before touching anything, since scripts still run in that mode here).
2. Ran the full verification suite (audit, lint, typecheck, test) in an **isolated `rsync` copy** of the worktree under `/tmp`, installed there with a normal `npm ci`, so the shared `node_modules` was never touched by the actual verification run.
3. Confirmed via `git status` in the main repo that `node_modules` has zero diffs after this work.

## Before/after audit output

**Before** (`npm audit --omit=dev --audit-level=high`):
```
ajv       7.0.0-alpha.0 - 8.17.1   HIGH — GHSA-2g4f-4pwh-qvx6
fast-uri  3.0.0 - 3.1.3            HIGH — GHSA-v2hh-gcrm-f6hx, GHSA-4c8g-83qw-93j6
js-yaml   4.0.0 - 4.2.0            HIGH — GHSA-h67p-54hq-rp68, GHSA-52cp-r559-cp3m

3 high severity vulnerabilities
```

**After** (isolated install, `npm audit --omit=dev --audit-level=high`):
```
found 0 vulnerabilities
```

## Test plan

All run in the isolated `/tmp` copy against the new lockfile:

- [x] `npm audit --omit=dev --audit-level=high` → `found 0 vulnerabilities`
- [x] `npm run lint` → `0 errors` (7 pre-existing warnings, unrelated to this change)
- [x] `npm run typecheck` → clean, no output
- [x] `npm test` → `104 passed | 1 skipped (105 files)`, `1397 passed | 15 skipped (1412 tests)`, 0 failures

## Scope

This branch contains **only** `package.json` + `package-lock.json`. It does not touch, rebase, or merge PRs #172/#173/#174 — sequencing those onto this branch is a separate call. It also does not attempt the 75 development-scope Dependabot alerts (vite, vitest, rollup, tar, electron, minimatch, etc.) — those are explicitly out of scope for this surgical fix and should be handled separately (e.g. via `.github/dependabot.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HIGH `npm audit` findings in production dependencies to unblock the Security Scanning & Compliance CI gate. Updates `fast-uri`, `js-yaml`, and scopes `ajv` to patched versions without changing tooling deps.

- **Dependencies**
  - Override `fast-uri` to `3.1.4` (patches host confusion CVEs).
  - Bump `js-yaml` from `^4.1.0` to `^4.3.0` (patches DoS advisories).
  - Add nested overrides so `ajv` is `>=8.18.0` under `ajv-formats` and `conf` only; keep top-level `ajv@6` unchanged.
  - Result: `npm audit --omit=dev --audit-level=high` reports 0 vulnerabilities.

<sup>Written for commit 316f4b1894b7c27976b16f411a6f8e94b4c03c97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/ingest-assistant/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

