### PR TITLE
chore(ci): bump actions/cache v3 -> v4 in all four jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           cache: 'npm'
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -112,7 +112,7 @@ jobs:
           cache: 'npm'
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -201,7 +201,7 @@ jobs:
           cache: 'npm'
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -299,7 +299,7 @@ jobs:
           cache: 'npm'
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             node_modules


### PR DESCRIPTION
## Summary

Four jobs in `.github/workflows/ci.yml` (lines 41, 115, 204, 302) use `actions/cache@v3`. GitHub has been retiring older cache action versions; if v3 is retired during an unattended period, all four CI jobs would fail with no change on our side — this is the only self-inflicting CI failure mode identified in the repo (everything else builds deterministically from the lockfile).

## Change

Bumped all four occurrences to `actions/cache@v4`. Nothing else touched — same `path:` lists, same `key:`/`restore-keys:` expressions, same `actions/setup-node@v4` with its built-in `cache: 'npm'`. v4 is API-compatible with v3 for this usage; no incompatibilities found in the `path`/`key` blocks as written, so no restructuring was needed or done.

## Scope

`.github/workflows/ci.yml` only. This PR is deliberately independent of the Electron lockfile bump (separate PR) — they touch disjoint files, so there's no conflict or required ordering, and a revert of one never has to drag the other along.

## Test plan

- [x] Diff is exactly 4 lines changed, all `actions/cache@v3` -> `actions/cache@v4`, no other edits
- [ ] All CI jobs green on this PR (verifying now)
- [ ] Cache steps actually execute (not silently skipped) — confirming in CI run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped `actions/cache` from v3 to v4 across all four CI jobs in `.github/workflows/ci.yml` to keep CI stable and avoid cache step failures if v3 is retired. Paths/keys and `actions/setup-node@v4` with `cache: 'npm'` are unchanged.

<sup>Written for commit 59fc5a5e78947fa22feb48e8adc44f4921d229f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/ingest-assistant/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

