### PR TITLE
chore(deps): bump electron 39.2.5 -> 39.8.10 (lockfile only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5601,9 +5601,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "39.2.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-39.2.5.tgz",
-      "integrity": "sha512-LXlOcH3CNopcVTQWjp680fMygdNrWKdIe3hyMtlyceO+Jd0b2hdMw1iWz36I+UUXHXPH87i937gXYi0jze2fCw==",
+      "version": "39.8.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.10.tgz",
+      "integrity": "sha512-zbYtGPYUI7PzqLAzkk21Rk6j67WN0hxn0Mq/njErZo1d0HSf33is4f8ICI5fMLy5vYe0JtCtM5sYunNOaochSQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",


### PR DESCRIPTION
## Summary

Dependabot reports 18 Electron advisories against 39.2.5 (5 HIGH, rest moderate/low). Electron sits in `devDependencies`, so it falls through both safety nets: Dependabot labels it "development" scope, and CI's `npm audit --production --audit-level=high` gate never sees it — but Electron is the actual runtime shipped to users in the packaged app. All 5 HIGH are patched by 39.8.1; 39.8.5 clears the remaining low-severity ones. 39.8.10 is the current 39.x tip.

**The 5 HIGH advisories closed by this bump:**
- Context Isolation bypass via contextBridge VideoFrame transfer ([GHSA-jfqg-hf23-qpw2](https://github.com/advisories/GHSA-jfqg-hf23-qpw2))
- Renderer command-line switch injection via undocumented commandLineSwitches webPreference ([GHSA-9wfr-w7mm-pc7f](https://github.com/advisories/GHSA-9wfr-w7mm-pc7f))
- Use-after-free in offscreen child window paint callback ([GHSA-532v-xpq5-8h95](https://github.com/advisories/GHSA-532v-xpq5-8h95))
- Use-after-free in WebContents fullscreen, pointer-lock, and keyboard-lock permission callbacks ([GHSA-8337-3p73-46f4](https://github.com/advisories/GHSA-8337-3p73-46f4))
- Use-after-free in PowerMonitor on Windows and macOS ([GHSA-jjp3-mq3x-295m](https://github.com/advisories/GHSA-jjp3-mq3x-295m))

## Change

`package.json` is **deliberately unchanged** — the declared range `"^39.2.5"` already admits 39.8.10; only the lockfile pinned the older patch (`39.2.5`). Ran `npm update electron --package-lock-only`, which touched exactly 3 lines in `package-lock.json` (`version`, `resolved`, `integrity` for the `electron` entry) and nothing else. Stayed on the 39.x line — no move to Electron 40, per scope.

## Native module risk: keytar rebuild — verified explicitly

`postinstall` runs `electron-rebuild -f -w keytar`. This was the primary risk: if keytar rebuilt against the wrong ABI, credential storage would break silently at runtime, only visible in a packaged app on real hardware, not in CI or the test suite.

Verified in an isolated install (see "How this was verified" below):
- `keytar` declares `"binary": {"napi_versions": [3]}` — it's an **N-API v3** module, which is ABI-stable by design across Node/Electron versions. `electron-rebuild` does not recompile it from source; it fetches the platform-matched prebuilt binary via `prebuild-install`.
- Confirmed via `electron-rebuild` debug trace:
  ```
  electron-rebuild checking keytar against []
  electron-rebuild assuming is prebuild-install powered: keytar
  electron-rebuild triggering prebuild download step: keytar
  electron-rebuild installed prebuilt module: keytar
  ✔ Rebuild Complete
  ```
- Went further than "the log said success" — **functionally exercised the rebuilt module against the real macOS Keychain**:
  ```
  write/read match: true {"wrote":"verify-1785589448750","read":"verify-1785589448750"}
  cleanup deleted: true
  ```
  Wrote a credential, read it back, confirmed the value matched, deleted it. This is empirical proof the rebuilt binary is not just present but functional.

## ffmpeg/ffprobe installer step

Confirmed the `postinstall` script's platform-directory creation step (`@ffmpeg-installer/{darwin-arm64,darwin-x64,win32-ia32,win32-x64,linux-arm,linux-arm64,linux-ia32}`) still ran correctly and all seven directories were created alongside the real `@ffmpeg-installer/ffmpeg` and `@ffprobe-installer/ffprobe` binaries for this platform (darwin-arm64).

## Shared node_modules symlink hazard

Same hazard as the previous dependency PR (#175): this worktree's `node_modules` symlinks to the main repo's shared install at `/Volumes/HestAI-Projects/ingest-assistant/node_modules`. Used the same approach:
1. Regenerated the lockfile with `npm update electron --package-lock-only` in the worktree (lockfile-only, no `node_modules` writes).
2. Ran the full verification (audit, lint, typecheck, test, keytar rebuild) in an isolated `rsync` copy under `/tmp`, installed there with a fresh `npm ci`.
3. Confirmed via `git status` in the main repo (`/Volumes/HestAI-Projects/ingest-assistant`) that the shared install has **zero diffs** after this work.

## CI does not package a DMG

`ci.yml`'s build job runs `npm run build` (vite + tsc only) — `electron-builder` is never invoked in CI. **CI passing does not prove the packaged app works.** On-device DMG testing is mandatory, not optional, and is the operator's to run before departure.

## Operator DMG checklist (mandatory, on real test hardware)

- [ ] App launches without error
- [ ] Credential storage via keytar works: save an API key in Settings, quit, relaunch, confirm it reads back correctly
- [ ] Media preview renders (open a clip/image and confirm the preview displays)
- [ ] A CFEx transfer completes end to end
- [ ] Proxy generation runs — confirms ffmpeg/ffprobe resolve correctly from inside the packaged ASAR (this is a different code path than the isolated dev verification above, which only proves the *installer* directories were created, not that the packaged binaries resolve at runtime)

## Before/after audit (dev-inclusive, informational — Electron isn't in the production CI gate's scope)

**Before** (electron 39.2.5): 33 vulnerabilities (2 low, 2 moderate, **24 high**, 5 critical) — includes 1 electron finding (severity: high, bundling the 5 named HIGH + 13 moderate/low advisories, range `<=39.8.4`)
**After** (electron 39.8.10): 32 vulnerabilities (2 low, 2 moderate, **23 high**, 5 critical) — electron finding gone entirely; no other package's resolution moved

## Test plan

All run in the isolated `/tmp` copy against `electron@39.8.10`:
- [x] `npm run lint` → 0 errors (7 pre-existing warnings, identical set to before)
- [x] `npm run typecheck` → clean, no output
- [x] `npm test` → 106 passed | 1 skipped (107 files), 1461 passed | 15 skipped (1476 tests), 0 failures
- [x] Resolved electron version confirmed at `39.8.10`
- [x] keytar rebuild verified via debug trace + live functional Keychain write/read/delete

## Scope

`package-lock.json` only — 3 lines changed. Does not touch `electron-builder`/`app-builder-lib`/`builder-util-runtime` (deliberately parked per instructions: CI never invokes electron-builder, packaging happens on the operator's machine, and that 26.0→26.15 minor bump changes packaging behavior in ways that could fail silently in a DMG — wrong risk to take before a month away). Independent of #176 (CI cache bump) — disjoint files, no ordering dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lockfile-only bump of `electron` from 39.2.5 to 39.8.10 to address security advisories (incl. 5 HIGH) while staying on 39.x. No `package.json` or app code changes; `keytar` rebuild and media tool postinstall steps validated.

- **Dependencies**
  - Updated `package-lock.json` for `electron` 39.2.5 → 39.8.10 (version/resolved/integrity).
  - `package.json` range stays `^39.2.5`; no other packages changed.

- **Migration**
  - Build and test a packaged app on device.
  - Verify `keytar` credentials persist across relaunch.
  - Confirm `@ffmpeg-installer/ffmpeg` and `@ffprobe-installer/ffprobe` execute correctly in the packaged app.

<sup>Written for commit 52309737917db74581bdb53d6844c3523f7f185e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/ingest-assistant/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

