### PR TITLE
chore(release): bump version to 3.1.0 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.1.0] - 2026-08-01
+
+### Added
+
+- Automatic dark mode that follows the OS appearance setting, via a semantic CSS variable / design-token system (#173)
+- App version displayed in the sidebar footer (#171)
+
+### Fixed
+
+- Raised the exiftool metadata-write timeout from 30 seconds to 3 minutes (`EXIFTOOL_TIMEOUT_MS`), fixing spurious write failures on large ProRes/MOV files (#174)
+
+### Changed
+
+- Explicit `build.asarUnpack` configuration for ffmpeg, ffprobe, and the keytar native module, replacing reliance on electron-builder's internal `smartUnpack` heuristic to decide whether these binaries end up executable in a packaged build; removed five `build.files` exclusions for `@ffmpeg-installer` platform packages left over from 3.0.1 that never actually matched anything (#178)
+- Added an automated test guarding the ffmpeg/ffprobe/keytar packaging configuration, so future edits to it can't silently break proxy generation in a packaged build (#178)
+- Refreshed `package-lock.json` and synced its version fields with `package.json` (#172)
+- Removed `pnpm-lock.yaml` — this project installs with npm, not pnpm (#171)
+- CI: bumped `actions/cache` from v3 to v4 in all four workflow jobs, ahead of GitHub's retirement of older cache action versions (#176)
+
+### Security
+
+- Updated `fast-uri` to 3.1.4, `js-yaml` to ^4.3.0, and scoped `ajv` overrides, clearing HIGH-severity npm audit findings that were blocking CI (#175)
+- Updated Electron from 39.2.5 to 39.8.10, closing 5 HIGH-severity advisories: a context-isolation bypass via `contextBridge` VideoFrame transfer, renderer command-line switch injection via undocumented `commandLineSwitches`, and three use-after-free issues (offscreen child window paint callback, WebContents fullscreen/pointer-lock/keyboard-lock permission callbacks, PowerMonitor) (#177)
+- Updated `electron-builder` from 26.0.12 to 26.15.7, closing HIGH-severity advisories in `app-builder-lib` and `builder-util-runtime` (#178)
+
+### Known Issues
+
+- **Linux `.deb`/AppImage builds produced from this version may ship a non-executable `ffprobe` binary** (permission mode `0644` instead of the executable `0755`), a side effect of the electron-builder 26.15.7 packaging engine — see #179. **macOS builds are unaffected**, verified directly against the packaged `.app` bundle before this release. This does not affect any already-published Linux build; it affects only a *future* Linux build cut from this version. **Linux releases are blocked until #179 is resolved.**
+
+---
+
 ## [3.0.2] - 2026-07-02
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ingest-assistant",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ingest-assistant",
-      "version": "3.0.2",
+      "version": "3.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ingest-assistant",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "AI-powered media file ingestion and metadata assistant with keyboard shortcuts, virtual scrolling, and enhanced security",
   "main": "dist/electron/electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Version bump and CHANGELOG update only — the last PR before the operator builds the DMG and departs for 30 days. No packaging, dependency, or build-config changes; all of that work is already merged (#175, #176, #177, #178).

**3.1.0, not 3.0.3** — per operator decision, not second-guessed here: this release adds features (automatic dark mode, sidebar version display), and `CHANGELOG.md` explicitly declares the project adheres to Semantic Versioning, which requires a minor bump for added functionality.

## Version bump — how it was done and verified

Ran `npm version 3.1.0 --no-git-tag-version` in an isolated `/tmp` copy (never against the shared `node_modules`) rather than hand-editing, so the lockfile update comes from the tool. Verified rather than assumed:

- `package.json`: `"version": "3.0.2"` -> `"version": "3.1.0"` (1 line)
- `package-lock.json`: **both** version fields updated and in agreement with `package.json` — the top-level `"version"` field and the `packages[""].version` field (the root package entry). A mismatch between these two is exactly what PR #172 was cleaning up earlier in this dependency-hardening sequence, so both were checked explicitly, not assumed to move together.

**Caught and fixed one thing before committing:** applying the isolated copy's lockfile diff to this worktree via a naive find-and-replace also touched an unrelated package (`sirv`, which happens to also be pinned at version `3.0.2` — pure coincidence of version strings) whose `resolved` URL still said `sirv-3.0.2.tgz` after the erroneous edit. Reverted that one line and re-diffed against the tool's own output until byte-identical. **Final lockfile diff is exactly the two version fields:**

```diff
diff --git a/package-lock.json b/package-lock.json
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ingest-assistant",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ingest-assistant",
-      "version": "3.0.2",
+      "version": "3.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
```

No git tag created — that's the operator's step after merge, not this PR's.

## CHANGELOG

`[Unreleased]` was empty, so everything merged since 3.0.2 was undocumented. Wrote it out as `[3.1.0] - 2026-08-01`, derived from the actual commit history (`git log` between the 3.0.2 release commit and current `main`, PRs #171-178) rather than from a summary, and cross-checked against each PR's actual diff. Category ordering follows the existing 3.0.1 precedent in this file: Added, Fixed, Changed, Security.

**Added**
- Automatic dark mode following OS appearance, via a semantic CSS variable/design-token system (#173)
- App version displayed in the sidebar footer (#171)

**Fixed**
- exiftool metadata-write timeout raised 30s -> 3 minutes (`EXIFTOOL_TIMEOUT_MS`), fixing spurious failures on large ProRes/MOV files (#174)

**Changed**
- Explicit `build.asarUnpack` for ffmpeg/ffprobe/keytar, replacing electron-builder's `smartUnpack` heuristic; removed five dead `build.files` `@ffmpeg-installer` exclusions left over from 3.0.1 that never matched anything (#178)
- Added an automated test guarding that packaging configuration against silent future breakage (#178) — kept brief since this is a maintainer-facing line, not a user-facing feature, but it encodes a real packaging contract worth a mention
- `package-lock.json` refreshed and version-synced with `package.json` (#172)
- `pnpm-lock.yaml` removed — this project installs with npm, not pnpm (#171)
- CI: `actions/cache` v3 -> v4 in all four jobs (#176)

**Security**
- `fast-uri` -> 3.1.4, `js-yaml` -> ^4.3.0, scoped `ajv` overrides — clears HIGH npm-audit findings that were blocking CI (#175)
- Electron 39.2.5 -> 39.8.10 — closes 5 HIGH advisories: contextBridge VideoFrame context-isolation bypass, `commandLineSwitches` command-line injection, and three use-after-frees (#177)
- `electron-builder` 26.0.12 -> 26.15.7 — closes HIGH advisories in `app-builder-lib` and `builder-util-runtime` (#178)

**Known Issues** (new subsection — placed directly under 3.1.0 so a person cutting a future Linux build sees it, not buried in an issue tracker)
- Linux `.deb`/AppImage builds from this version may ship `ffprobe` as non-executable (mode `0644`), a side effect of the electron-builder 26.15.7 bump — tracked as #179. **macOS is unaffected**, verified directly against the packaged `.app` bundle in #178. The already-published Linux build is unaffected — this is about a *future* Linux build, which is blocked until #179 resolves. Deliberately not overstated: this is not a regression in what's already shipped.

## Sidebar version display — confirmed correct, no defect

Traced the full chain before touching anything: `Sidebar.tsx` calls `window.electronAPI.getAppVersion()` -> preload bridge -> IPC handler `app:get-version` in `electron/ipc/appHandlers.ts` -> `app.getVersion()`. Electron's `app.getVersion()` reads the `version` field of the nearest `package.json` at runtime; there is no `app.setVersion()` call anywhere in the codebase overriding it, and no separate hardcoded or cached version string exists. **The `package.json` version bump alone is sufficient** — the sidebar will correctly show 3.1.0 with no other code change needed.

## Packaging — not re-run, correctly so

No `build.asarUnpack`, `build.files`, or any other packaging-relevant config changed in this PR — only `version` fields and the changelog. A version-only change cannot alter what electron-builder packages or how. The packaging verification from #178 (byte-identical `app.asar`, identical `app.asar.unpacked`, functional ffmpeg/ffprobe/keytar checks) stands unchanged and was not re-run here.

## Shared node_modules

Confirmed zero diffs at `/Volumes/HestAI-Projects/ingest-assistant` before and after this work — checked directly rather than assumed, per the note that a session hook had reinstalled it recently. It's now a full install that correctly matches current `main` (`electron@39.8.10`, `electron-builder@26.15.7`) — an external process, not something this PR's work touched or needs to account for further; all verification for this PR ran in an isolated `/tmp` copy as with every prior PR in this sequence.

## Test plan (isolated `/tmp` copy, real output)

```
$ npm run lint
✖ 7 problems (0 errors, 7 warnings)      <- same 7 pre-existing warnings, unrelated

$ npm run typecheck
> ingest-assistant@3.1.0 typecheck
> tsc --noEmit && tsc -p electron/tsconfig.json --noEmit
(clean, no output — note the package name/version banner confirms 3.1.0 is live)

$ npm test
 Test Files  107 passed | 1 skipped (108)
      Tests  1463 passed | 15 skipped (1478)

$ npm audit --omit=dev --audit-level=high
found 0 vulnerabilities

$ npm run build
✓ built in 375ms
```

## Scope

`package.json` (version field), `package-lock.json` (both version fields), `CHANGELOG.md` only. No dependency changes of any kind — no `npm update`, no touched `overrides`, no resolutions dragged by the version bump (confirmed via the version-fields-only lockfile diff above). No git tag. No attempt at #179's Linux fix. No `.github/dependabot.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)